### PR TITLE
이슈목록화면의 컬렉션뷰 flow layout 설정을 UICollectionViewFlowLayout 객체를 사용하는 방식으로 수정

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueList.storyboard
@@ -37,24 +37,24 @@
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="VGO-WG-P6r">
                                 <rect key="frame" x="0.0" y="88" width="414" height="774"/>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
-                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="1" minimumInteritemSpacing="2" id="rRT-tx-TJG">
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="1" id="rRT-tx-TJG">
                                     <size key="itemSize" width="412" height="100"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
-                                    <inset key="sectionInset" minX="0.0" minY="2" maxX="0.0" maxY="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="10" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="IssueCell" id="aIG-2q-XR7" customClass="IssueCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="1" y="2" width="412" height="100"/>
+                                        <rect key="frame" x="1" y="10" width="412" height="100"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ONO-gj-CGL">
                                             <rect key="frame" x="0.0" y="0.0" width="412" height="100"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 전체 목록을 볼 수 있어야 한다. 2줄까지 보입니다. 뒷줄은 잘리게 될 것 입니다 쩜쩜쩜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rRY-D3-c3q">
-                                                    <rect key="frame" x="23" y="44" width="260" height="41"/>
+                                                    <rect key="frame" x="15" y="44" width="300" height="41"/>
                                                     <constraints>
-                                                        <constraint firstAttribute="width" constant="260" id="2tS-Pr-XBv"/>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="2tS-Pr-XBv"/>
                                                         <constraint firstAttribute="height" constant="41" id="bFF-6b-ZHC"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
@@ -108,7 +108,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </button>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 목록 보기 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Ac-H0-ytB">
-                                                    <rect key="frame" x="23" y="16" width="162.5" height="23"/>
+                                                    <rect key="frame" x="15" y="16" width="162.5" height="23"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="19"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -116,10 +116,11 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="zMu-hK-bfQ" firstAttribute="top" secondItem="btQ-GT-NEf" secondAttribute="bottom" constant="4" id="6SB-dC-WS3"/>
-                                                <constraint firstItem="7Ac-H0-ytB" firstAttribute="leading" secondItem="ONO-gj-CGL" secondAttribute="leading" constant="23" id="7IB-Gn-odC"/>
+                                                <constraint firstItem="7Ac-H0-ytB" firstAttribute="leading" secondItem="ONO-gj-CGL" secondAttribute="leading" constant="15" id="7IB-Gn-odC"/>
                                                 <constraint firstAttribute="trailing" secondItem="zMu-hK-bfQ" secondAttribute="trailing" constant="6" id="MbS-N1-2ak"/>
                                                 <constraint firstItem="btQ-GT-NEf" firstAttribute="top" secondItem="7Ac-H0-ytB" secondAttribute="top" id="QIL-rS-jk0"/>
                                                 <constraint firstItem="rRY-D3-c3q" firstAttribute="leading" secondItem="7Ac-H0-ytB" secondAttribute="leading" id="RBb-5Y-unO"/>
+                                                <constraint firstItem="zMu-hK-bfQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="rRY-D3-c3q" secondAttribute="trailing" constant="30" id="a1W-rO-tN7"/>
                                                 <constraint firstItem="rRY-D3-c3q" firstAttribute="top" secondItem="7Ac-H0-ytB" secondAttribute="bottom" constant="5" id="bQE-SC-JJ0"/>
                                                 <constraint firstItem="7Ac-H0-ytB" firstAttribute="top" secondItem="ONO-gj-CGL" secondAttribute="top" constant="16" id="jPF-lS-saF"/>
                                                 <constraint firstAttribute="trailing" secondItem="btQ-GT-NEf" secondAttribute="trailing" constant="8" id="tDk-Fk-9Ub"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -17,7 +17,20 @@ final class IssueListViewController: UIViewController {
         
         collectionView.dataSource = self
         collectionView.delegate = self
+        
+        collectionView.layoutIfNeeded()
+        configureLayout()
+        
+    }
+}
 
+extension IssueListViewController {
+    private func configureLayout() {
+        let collectionViewFlowLayout = UICollectionViewFlowLayout()
+        collectionViewFlowLayout.itemSize = CGSize(width: collectionView.bounds.size.width, height: 100)
+        collectionViewFlowLayout.minimumLineSpacing = 2
+        collectionViewFlowLayout.sectionInset = UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
+        collectionView.collectionViewLayout = collectionViewFlowLayout
     }
 }
 
@@ -34,13 +47,6 @@ extension IssueListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IssueCell.reuseIdentifier, for: indexPath) as! IssueCell
         return cell
-    }
-}
-
-extension IssueListViewController: UICollectionViewDelegateFlowLayout {
-    
-    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CGSize(width: collectionView.bounds.size.width, height: 100 )
     }
 }
 


### PR DESCRIPTION
# 이슈목록화면의 컬렉션뷰 flow layout 설정을 UICollectionViewFlowLayout 객체를 사용하는 방식으로 수정

## 해당 이슈 📎

이슈 목록화면을 확인할 수 있다. https://github.com/boostcamp-2020/IssueTracker-7/issues/36

## 변경 사항 🛠

- 제목 그대로 수정하였습니다. 

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

- 학습정리에 얄팍한 학습 내용 추가하였습니다. 어느순간 야크셰이빙이 길어져서 그만두고 PR을 날립니다.. [iOS 학습정리](https://github.com/boostcamp-2020/IssueTracker-7/wiki/iOS-%ED%95%99%EC%8A%B5%EC%A0%95%EB%A6%AC#20201102)
