### PR TITLE
Github OAuth 인증 요청 경로를 web과 ios 로 분리

### DIFF
--- a/backend/routes/api/auth.js
+++ b/backend/routes/api/auth.js
@@ -37,6 +37,8 @@ router.get(
       case 'ios':
         redirectUrl = `IssueTracker://login#accessToken=${res.locals.accessToken}refreshToken=${res.locals.refreshToken}`;
         break;
+      default:
+        return res.status(404).send('유효하지 않은 요청 입니다.');
     }
     return res.redirect(redirectUrl);
   }

--- a/backend/routes/api/auth.js
+++ b/backend/routes/api/auth.js
@@ -3,7 +3,22 @@ var router = express.Router();
 
 const { createToken, verifyToken } = require('../../middlewares/token');
 
-router.get('/github', verifyToken('github'));
+router.get(
+  '/github/web',
+  (req, res, next) => {
+    res.cookie('media_type', 'web', { signed: true, httpOnly: true });
+    next();
+  },
+  verifyToken('github')
+);
+router.get(
+  '/github/ios',
+  (req, res, next) => {
+    res.cookie('media_type', 'ios', { signed: true, httpOnly: true });
+    next();
+  },
+  verifyToken('github')
+);
 
 router.get(
   '/github/callback',
@@ -14,7 +29,16 @@ router.get(
   (req, res) => {
     res.cookie('accessToken', res.locals.accessToken, { signed: true, httpOnly: true });
     res.cookie('refreshToken', res.locals.refreshToken, { signed: true, httpOnly: true });
-    return res.redirect('/');
+    let redirectUrl = null;
+    switch (req.signedCookies.media_type) {
+      case 'web':
+        redirectUrl = '/';
+        break;
+      case 'ios':
+        redirectUrl = `IssueTracker://login#accessToken=${res.locals.accessToken}refreshToken=${res.locals.refreshToken}`;
+        break;
+    }
+    return res.redirect(redirectUrl);
   }
 );
 


### PR DESCRIPTION
# Github OAuth 인증 요청 경로를 web과 ios 로 분리

## 해당 이슈 📎

#2

## 변경 사항 🛠

구현내용 요약

- Github OAuth 인증 요청 경로를 Web과 ios로 분리한다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

