### PR TITLE
복수의 association 을 가지는 Model의 관계에 alias 적용

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -1,3 +1,4 @@
+const { authorize } = require('passport');
 const path = require('path');
 const Sequelize = require('sequelize');
 
@@ -16,33 +17,73 @@ db.Issue = require('./issue')(sequelize, Sequelize);
 db.Label = require('./label')(sequelize, Sequelize);
 db.Milestone = require('./milestone')(sequelize, Sequelize);
 
-db.User.belongsToMany(db.Issue, {
-  through: 'assignees',
-});
-db.Issue.belongsToMany(db.User, {
-  through: 'assignees',
-});
-
-db.User.hasMany(db.Comment, {
-  foreignKey: 'user_id',
-  sourceKey: 'id',
-});
-db.Comment.belongsTo(db.User, {
-  foreignKey: 'user_id',
-  sourceKey: 'id',
-});
-
 db.User.hasMany(db.Issue, {
+  as: 'written',
   foreignKey: 'user_id',
   sourceKey: 'id',
+});
+db.User.belongsToMany(db.Issue, {
+  as: 'assigned',
+  through: 'user_has_issue',
+});
+db.User.hasMany(db.Comment, {
+  as: 'comments',
+  foreignKey: 'user_id',
+  sourceKey: 'id',
+});
+
+db.Issue.belongsToMany(db.User, {
+  as: 'assignees',
+  through: 'user_has_issue',
 });
 db.Issue.belongsTo(db.User, {
+  as: 'author',
   foreignKey: 'user_id',
   targetKey: 'id',
 });
-
 db.Issue.hasMany(db.Comment, {
   foreignKey: 'issue_id',
+  sourceKey: 'id',
+});
+db.Issue.belongsTo(db.Milestone, {
+  foreignKey: 'milestone_id',
+  targetKey: 'id',
+});
+db.Issue.hasMany(db.label_has_issue, {
+  foreignKey: 'issue_id',
+  sourceKey: 'id',
+});
+db.Issue.belongsToMany(db.Label, {
+  as: 'labels',
+  through: db.label_has_issue,
+});
+
+db.label_has_issue = sequelize.define(
+  'label_has_issue',
+  {},
+  { underscored: true, tableName: 'label_has_issue', timestamps: true }
+);
+db.label_has_issue.belongsTo(db.Label, {
+  foreignKey: 'label_id',
+  targetKey: 'id',
+});
+db.label_has_issue.belongsTo(db.Issue, {
+  foreignKey: 'issue_id',
+  targetKey: 'id',
+});
+
+db.Label.hasMany(db.label_has_issue, {
+  foreignKey: 'label_id',
+  sourceKey: 'id',
+});
+db.Label.belongsToMany(db.Issue, {
+  as: 'issues',
+  through: db.label_has_issue,
+});
+
+db.Comment.belongsTo(db.User, {
+  as: 'mentions',
+  foreignKey: 'user_id',
   sourceKey: 'id',
 });
 db.Comment.belongsTo(db.Issue, {
@@ -54,15 +95,5 @@ db.Milestone.hasMany(db.Issue, {
   foreignKey: 'milestone_id',
   sourceKey: 'id',
 });
-db.Issue.belongsTo(db.Milestone, {
-  foreignKey: 'milestone_id',
-  targetKey: 'id',
-});
 
-db.Issue.belongsToMany(db.Label, {
-  through: 'label_has_issue',
-});
-db.Label.belongsToMany(db.Issue, {
-  through: 'label_has_issue',
-});
 module.exports = db;


### PR DESCRIPTION
# 복수의 association 을 가지는 Model의 관계에 alias 적용

## 해당 이슈 📎

#51

## 변경 사항 🛠

구현내용 요약

- 복수의 관계를 가지는 model을 join 할 때 관계를 식별하기 위한 alias를 추가한다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

