### PR TITLE
GitHub 로그인 버튼 생성

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1033,6 +1033,27 @@
       "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
+    "@fortawesome/fontawesome-common-types": {
+      "version": "0.2.32",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.32.tgz",
+      "integrity": "sha512-ux2EDjKMpcdHBVLi/eWZynnPxs0BtFVXJkgHIxXRl+9ZFaHPvYamAfCzeeQFqHRjuJtX90wVnMRaMQAAlctz3w=="
+    },
+    "@fortawesome/free-brands-svg-icons": {
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-5.15.1.tgz",
+      "integrity": "sha512-pkTZIWn7iuliCCgV+huDfZmZb2UjslalXGDA2PcqOVUYJmYL11y6ooFiMJkJvUZu+xgAc1gZgQe+Px12mZF0CA==",
+      "requires": {
+        "@fortawesome/fontawesome-common-types": "^0.2.32"
+      }
+    },
+    "@fortawesome/react-fontawesome": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.12.tgz",
+      "integrity": "sha512-kV6HtqotM3K4YIXlTVvomuIi6QgGCvYm++ImyEx2wwgmSppZ6kbbA29ASwjAUBD63j2OFU0yoxeXpZkjrrX0qQ==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -5003,6 +5024,16 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
+    },
+    "prop-types": {
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
+      }
     },
     "proxy-addr": {
       "version": "2.0.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,8 @@
     "@babel/core": "^7.12.3",
     "@babel/preset-env": "^7.12.1",
     "@babel/preset-react": "^7.12.1",
+    "@fortawesome/free-brands-svg-icons": "^5.15.1",
+    "@fortawesome/react-fontawesome": "^0.1.12",
     "babel-loader": "^8.1.0",
     "babel-polyfill": "^6.26.0",
     "clean-webpack-plugin": "^3.0.0",

--- a/frontend/src/components/login/GitHubButton.jsx
+++ b/frontend/src/components/login/GitHubButton.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Button = styled.button`
+    width: 100%;
+    height: 33px;
+    font-weight: bold;
+    color: #ffffff;
+    background-color: #a3a3a3;
+    border-radius: 3px;
+    border: none;
+    outline: none;
+    cursor: pointer;
+`;
+
+const GithubButton = ({ onClick, children }) => {
+    return (
+        <Button onClick={onClick}>{children}</Button>
+    );
+};
+
+export default GithubButton;

--- a/frontend/src/components/login/GitHubButton.jsx
+++ b/frontend/src/components/login/GitHubButton.jsx
@@ -13,7 +13,7 @@ const Button = styled.button`
     cursor: pointer;
 `;
 
-const GithubButton = ({ onClick, children }) => {
+const GithubButton = ({ onClick, children, image }) => {
     return (
         <Button onClick={onClick}>{children}{image}</Button>
     );

--- a/frontend/src/components/login/GitHubButton.jsx
+++ b/frontend/src/components/login/GitHubButton.jsx
@@ -15,7 +15,7 @@ const Button = styled.button`
 
 const GithubButton = ({ onClick, children }) => {
     return (
-        <Button onClick={onClick}>{children}</Button>
+        <Button onClick={onClick}>{children}{image}</Button>
     );
 };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import GithubButton from '../components/login/GithubButton';
-import{ FontAwesomeIcon }from"@fortawesome/react-fontawesome";
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
+import '@fortawesome/fontawesome-free/js/all';
 
 const LoginPage = () => {
     const handleGitHubLogin = () => {
         location.href = '/api/auth/github/web';
     };
     return (
-        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub <FontAwesomeIcon icon={faGithub} /></GithubButton>
+        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub <i className="fab fa-github" /></GithubButton>
     );
 };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import GithubButton from '../components/login/GithubButton';
+
+const LoginPage = () => {
+    const handleGitHubLogin = () => {
+        location.href = '/api/auth/github/web';
+    };
+    return (
+        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub</GithubButton>
+    );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,13 +1,16 @@
 import React from 'react';
 import GithubButton from '../components/login/GithubButton';
-import '@fortawesome/fontawesome-free/js/all';
+import{ FontAwesomeIcon }from"@fortawesome/react-fontawesome";
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 const LoginPage = () => {
     const handleGitHubLogin = () => {
         location.href = '/api/auth/github/web';
     };
     return (
-        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub <i className="fab fa-github" /></GithubButton>
+        <GithubButton onClick={handleGitHubLogin}>
+            Sign with GitHub <FontAwesomeIcon icon={faGithub} />
+        </GithubButton>
     );
 };
 

--- a/frontend/src/pages/LoginPage.jsx
+++ b/frontend/src/pages/LoginPage.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import GithubButton from '../components/login/GithubButton';
+import{ FontAwesomeIcon }from"@fortawesome/react-fontawesome";
+import { faGithub } from '@fortawesome/free-brands-svg-icons';
 
 const LoginPage = () => {
     const handleGitHubLogin = () => {
         location.href = '/api/auth/github/web';
     };
     return (
-        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub</GithubButton>
+        <GithubButton onClick={handleGitHubLogin}>Sign with GitHub <FontAwesomeIcon icon={faGithub} /></GithubButton>
     );
 };
 


### PR DESCRIPTION
# GitHub 로그인 버튼 생성

## 해당 이슈 📎

#12

## 변경 사항 🛠

구현내용 요약

- 깃허브 로그인 버튼 컴포넌트 구현
- 로그인 페이지 생성 및 깃허브 로그인 버튼 추가
- 깃허브 이미지 추가

## 테스트 ✨

![image](https://user-images.githubusercontent.com/61968474/98194282-5ba92580-1f62-11eb-8556-160b7de130fe.png)



## 리뷰어 참고 사항 🙋‍♀️

- width 속성은 추후에 수정