### PR TITLE
이슈 목록 조회 시 상단 Comment 하나를 같이 반환하도록 구현

### DIFF
--- a/backend/controllers/issue.js
+++ b/backend/controllers/issue.js
@@ -76,16 +76,21 @@ exports.get = async (req, res) => {
     },
     {
       model: Comment,
-      include: {
-        model: User,
-        as: 'mentions',
-        where:
-          query.mentions == '@me'
-            ? {
-                user_id: query.mentions,
-              }
-            : null,
-      },
+      limit: 1,
+      include: [
+        {
+          model: User,
+          as: 'mentions',
+          where:
+            query.mentions == '@me'
+              ? {
+                  user_id: query.mentions,
+                }
+              : null,
+          attributes: ['id', 'user_id', 'photo_url', 'type'],
+        },
+      ],
+      attributes: ['id', 'content', 'created_at', 'updated_at', 'user_id'],
     },
     {
       model: Milestone,

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -84,11 +84,11 @@ db.Label.belongsToMany(db.Issue, {
 db.Comment.belongsTo(db.User, {
   as: 'mentions',
   foreignKey: 'user_id',
-  sourceKey: 'id',
+  targetKey: 'id',
 });
 db.Comment.belongsTo(db.Issue, {
   foreignKey: 'issue_id',
-  sourceKey: 'id',
+  targetKey: 'id',
 });
 
 db.Milestone.hasMany(db.Issue, {


### PR DESCRIPTION
# 이슈 목록 조회 시 상단 Comment 하나를 같이 반환하도록 구현

## 해당 이슈 📎

#139

## 변경 사항 🛠

구현내용 요약

- iOS는 이슈 목록에서 Comment의 미리보기를 지원하므로 이슈 목록 조회 시 상단 Comment 하나를 같이 반환하도록 구현한다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

