### PR TITLE
단일 이슈 조회의 반환 양식 수정

### DIFF
--- a/backend/controllers/issue.js
+++ b/backend/controllers/issue.js
@@ -138,7 +138,16 @@ exports.getAll = async (req, res) => {
 
 exports.getOne = (req, res) => {
   const issue_id = req.params.issue_id;
-  return Issue.findByPk(issue_id)
+  return Issue.findByPk(issue_id, {
+    attributes: ['id', 'title', 'status', 'created_at', 'updated_at'],
+    include: [
+      {
+        model: User,
+        as: 'author',
+        attributes: ['id', 'user_id', 'photo_url', 'type'],
+      },
+    ],
+  })
     .then((issue) => {
       if (issue) res.status(200).json(issue);
       else res.status(401).send('유효하지 않은 Label 입니다.');


### PR DESCRIPTION
# 단일 이슈 조회의 반환 양식 수정

## 해당 이슈 📎

#139

## 변경 사항 🛠

구현내용 요약

- API 문서의 수정에 따라 단일 이슈 조회의 반환 양식을 수정한다.

## 테스트 ✨

![image](https://user-images.githubusercontent.com/26570319/98203643-c7e25400-1f77-11eb-8644-5e2ae65310e9.png)

## 리뷰어 참고 사항 🙋‍♀️

