### PR TITLE
작성자와 제목, 오픈 여부, 이슈번호(#1)를 형식으로 볼 수 있다

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		33151F3E254A6464006B94A9 /* FilteringController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33151F3D254A6464006B94A9 /* FilteringController.swift */; };
 		33151F43254A6E55006B94A9 /* FilteringTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33151F42254A6E55006B94A9 /* FilteringTableViewController.swift */; };
 		3322CF7E25539E3B0022ABA6 /* Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322CF7D25539E3B0022ABA6 /* Comment.swift */; };
-		3322CFA52553B8810022ABA6 /* AppleSignInButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322CFA42553B8810022ABA6 /* AppleSignInButton.swift */; };
 		3322CFAA2553B8900022ABA6 /* AppleSignInButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3322CFA92553B8900022ABA6 /* AppleSignInButton.swift */; };
 		3328A979254B14F600126761 /* EndPointable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3328A978254B14F600126761 /* EndPointable.swift */; };
 		3328A97F254B155000126761 /* GithubAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3328A97E254B155000126761 /* GithubAPI.swift */; };
@@ -98,7 +97,6 @@
 		33151F3D254A6464006B94A9 /* FilteringController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteringController.swift; sourceTree = "<group>"; };
 		33151F42254A6E55006B94A9 /* FilteringTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilteringTableViewController.swift; sourceTree = "<group>"; };
 		3322CF7D25539E3B0022ABA6 /* Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comment.swift; sourceTree = "<group>"; };
-		3322CFA42553B8810022ABA6 /* AppleSignInButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = AppleSignInButton.swift; path = IssueTracker/View/AppleSignInButton/AppleSignInButton.swift; sourceTree = SOURCE_ROOT; };
 		3322CFA92553B8900022ABA6 /* AppleSignInButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppleSignInButton.swift; sourceTree = "<group>"; };
 		3328A978254B14F600126761 /* EndPointable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EndPointable.swift; sourceTree = "<group>"; };
 		3328A97E254B155000126761 /* GithubAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubAPI.swift; sourceTree = "<group>"; };
@@ -442,7 +440,6 @@
 		3393E0D025530B0B003DCDA4 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
-				3322CFA42553B8810022ABA6 /* AppleSignInButton.swift */,
 				3393E0D125530B33003DCDA4 /* IssueCell.swift */,
 			);
 			path = Cell;
@@ -483,8 +480,8 @@
 				712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */,
 			);
 			path = RegisterIssue;
-               sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		7130A68E2551636900EE2141 /* ManageLabel */ = {
 			isa = PBXGroup;
 			children = (
@@ -663,8 +660,7 @@
 				33375CB12548595700E8A8E8 /* OAuthManager.swift in Sources */,
 				33375C3A2547E70E00E8A8E8 /* AppDelegate.swift in Sources */,
 				712CBEA6255008B700E8F95F /* RegisterIssueViewController.swift in Sources */,
-				33375CB725487A1700E8A8E8 /* AppleSignInButton.swift in Sources */,
-				3358A57C254ED757008CEFA3 /* StoryboardName.swift in Sources */,
+				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				333FE2AA25515167000C0F0B /* DetailIssueListController.swift in Sources */,
 				7130A6A025527E8900EE2141 /* ManageLabelModalView.swift in Sources */,
 				7130A69525516AC500EE2141 /* ManageLabelViewController.swift in Sources */,
@@ -695,7 +691,6 @@
 				7130A6D12552CD0F00EE2141 /* InputValidator.swift in Sources */,
 				339892B22549876B00D9FB63 /* UserInfo.swift in Sources */,
 				7130A6CC2552A2A700EE2141 /* UIColor+.swift in Sources */,
-				3322CFA52553B8810022ABA6 /* AppleSignInButton.swift in Sources */,
 				3322CFAA2553B8900022ABA6 /* AppleSignInButton.swift in Sources */,
 				339892A125497CB400D9FB63 /* UserDefault.swift in Sources */,
 				3393E09525523D29003DCDA4 /* CardView.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		3398929925493ADD00D9FB63 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33375C8B2547F59500E8A8E8 /* Router.swift */; };
 		339892A125497CB400D9FB63 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892A025497CB400D9FB63 /* UserDefault.swift */; };
 		339892B22549876B00D9FB63 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892B12549876B00D9FB63 /* UserInfo.swift */; };
+		33A108DA2553C9B7007F1BB2 /* DetailIssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */; };
 		33BD8DD3254989E100537960 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BD8DD2254989E100537960 /* NotificationName.swift */; };
 		33BD8DDA25498DC000537960 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892B12549876B00D9FB63 /* UserInfo.swift */; };
 		33BD8DDE25498E0300537960 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892A025497CB400D9FB63 /* UserDefault.swift */; };
@@ -142,6 +143,7 @@
 		3393E0D125530B33003DCDA4 /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		339892A025497CB400D9FB63 /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
 		339892B12549876B00D9FB63 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
+		33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueCell.swift; sourceTree = "<group>"; };
 		33BD8DD2254989E100537960 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		33BD8DE52549956B00537960 /* BackEndAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackEndAPIManager.swift; sourceTree = "<group>"; };
 		33F1C286254C70E1000E1649 /* GithubUserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubUserInfo.swift; sourceTree = "<group>"; };
@@ -441,6 +443,7 @@
 			isa = PBXGroup;
 			children = (
 				3393E0D125530B33003DCDA4 /* IssueCell.swift */,
+				33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -670,6 +673,7 @@
 				3393E0AC2552698C003DCDA4 /* UIView+.swift in Sources */,
 				3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */,
 				3393E0BD2552AACC003DCDA4 /* IssueData.swift in Sources */,
+				33A108DA2553C9B7007F1BB2 /* DetailIssueCell.swift in Sources */,
 				333FE28D25510BEC000C0F0B /* APICredentials.swift in Sources */,
 				3393E0D225530B33003DCDA4 /* IssueCell.swift in Sources */,
 				333FE2992551214A000C0F0B /* RegParser.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -53,7 +53,8 @@
 		3398929925493ADD00D9FB63 /* Router.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33375C8B2547F59500E8A8E8 /* Router.swift */; };
 		339892A125497CB400D9FB63 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892A025497CB400D9FB63 /* UserDefault.swift */; };
 		339892B22549876B00D9FB63 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892B12549876B00D9FB63 /* UserInfo.swift */; };
-		33A108DA2553C9B7007F1BB2 /* DetailIssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */; };
+		339F611E2553FF7B00FDB2A9 /* DetailIssueCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339F611D2553FF7B00FDB2A9 /* DetailIssueCell.swift */; };
+		33A108E32553DF54007F1BB2 /* DetailIssueInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33A108E22553DF54007F1BB2 /* DetailIssueInfo.swift */; };
 		33BD8DD3254989E100537960 /* NotificationName.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BD8DD2254989E100537960 /* NotificationName.swift */; };
 		33BD8DDA25498DC000537960 /* UserInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892B12549876B00D9FB63 /* UserInfo.swift */; };
 		33BD8DDE25498E0300537960 /* UserDefault.swift in Sources */ = {isa = PBXBuildFile; fileRef = 339892A025497CB400D9FB63 /* UserDefault.swift */; };
@@ -143,7 +144,8 @@
 		3393E0D125530B33003DCDA4 /* IssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCell.swift; sourceTree = "<group>"; };
 		339892A025497CB400D9FB63 /* UserDefault.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefault.swift; sourceTree = "<group>"; };
 		339892B12549876B00D9FB63 /* UserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfo.swift; sourceTree = "<group>"; };
-		33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueCell.swift; sourceTree = "<group>"; };
+		339F611D2553FF7B00FDB2A9 /* DetailIssueCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetailIssueCell.swift; sourceTree = "<group>"; };
+		33A108E22553DF54007F1BB2 /* DetailIssueInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueInfo.swift; sourceTree = "<group>"; };
 		33BD8DD2254989E100537960 /* NotificationName.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationName.swift; sourceTree = "<group>"; };
 		33BD8DE52549956B00537960 /* BackEndAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackEndAPIManager.swift; sourceTree = "<group>"; };
 		33F1C286254C70E1000E1649 /* GithubUserInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubUserInfo.swift; sourceTree = "<group>"; };
@@ -351,6 +353,7 @@
 				3358A5DD2550382E008CEFA3 /* FilterConditions */,
 				3358A5BE254FE609008CEFA3 /* Token */,
 				33F1C286254C70E1000E1649 /* GithubUserInfo.swift */,
+				33A108E22553DF54007F1BB2 /* DetailIssueInfo.swift */,
 			);
 			path = ValueObject;
 			sourceTree = "<group>";
@@ -442,8 +445,8 @@
 		3393E0D025530B0B003DCDA4 /* Cell */ = {
 			isa = PBXGroup;
 			children = (
+				339F611D2553FF7B00FDB2A9 /* DetailIssueCell.swift */,
 				3393E0D125530B33003DCDA4 /* IssueCell.swift */,
-				33A108D92553C9B7007F1BB2 /* DetailIssueCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -672,8 +675,8 @@
 				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				3393E0AC2552698C003DCDA4 /* UIView+.swift in Sources */,
 				3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */,
+				339F611E2553FF7B00FDB2A9 /* DetailIssueCell.swift in Sources */,
 				3393E0BD2552AACC003DCDA4 /* IssueData.swift in Sources */,
-				33A108DA2553C9B7007F1BB2 /* DetailIssueCell.swift in Sources */,
 				333FE28D25510BEC000C0F0B /* APICredentials.swift in Sources */,
 				3393E0D225530B33003DCDA4 /* IssueCell.swift in Sources */,
 				333FE2992551214A000C0F0B /* RegParser.swift in Sources */,
@@ -690,6 +693,7 @@
 				33375C3C2547E70E00E8A8E8 /* SceneDelegate.swift in Sources */,
 				33BD8DE62549956B00537960 /* BackEndAPIManager.swift in Sources */,
 				33F1C287254C70E1000E1649 /* GithubUserInfo.swift in Sources */,
+				33A108E32553DF54007F1BB2 /* DetailIssueInfo.swift in Sources */,
 				71531F57254A859F00CCFAE2 /* IssueListViewController.swift in Sources */,
 				7130A6B525528B2D00EE2141 /* ManageLabelModalViewController.swift in Sources */,
 				7130A6D12552CD0F00EE2141 /* InputValidator.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
@@ -27,25 +27,140 @@
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailIssueCell" id="aom-T0-G8J" customClass="DetailIssueCell" customModule="IssueTracker" customModuleProvider="target">
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailIssueTopCell" id="aom-T0-G8J" customClass="DetailIssueTopCell" customModule="IssueTracker" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Hc8-Z8-qld">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eux-uq-zld">
-                                                    <rect key="frame" x="126" y="54" width="42" height="21"/>
-                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sample_id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eux-uq-zld">
+                                                    <rect key="frame" x="42" y="16" width="49.5" height="12"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="hqS-El-3QW">
+                                                    <rect key="frame" x="12" y="17.5" width="20" height="17"/>
+                                                    <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="hqS-El-3QW" secondAttribute="height" multiplier="1:1" id="6ro-6A-fzV"/>
+                                                        <constraint firstAttribute="height" constant="20" id="sgt-50-486"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이슈 생성 기능(샘플 제목)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mX6-pD-2mh">
+                                                    <rect key="frame" x="12" y="41" width="222" height="26.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <button opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZyK-e8-H3I">
+                                                    <rect key="frame" x="12" y="80.5" width="87" height="35.5"/>
+                                                    <color key="backgroundColor" red="0.93597036600000005" green="0.98519843819999997" blue="0.94798022510000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="87" id="5jM-Ww-jDl"/>
+                                                    </constraints>
+                                                    <color key="tintColor" red="0.23848453159999999" green="0.60863178969999998" blue="0.30887034540000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    <state key="normal" title="Open" image="exclamationmark.circle" catalog="system">
+                                                        <color key="titleColor" red="0.32001247999999999" green="0.64639794829999997" blue="0.32851567860000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                    </state>
+                                                </button>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="#11" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ovY-ko-qAz">
+                                                    <rect key="frame" x="376.5" y="12" width="25.5" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="eux-uq-zld" firstAttribute="leading" secondItem="hqS-El-3QW" secondAttribute="trailing" constant="10" id="7T2-am-MhE"/>
+                                                <constraint firstAttribute="bottom" secondItem="ZyK-e8-H3I" secondAttribute="bottom" constant="12" id="K5S-Ne-qaS"/>
+                                                <constraint firstItem="ZyK-e8-H3I" firstAttribute="top" secondItem="mX6-pD-2mh" secondAttribute="bottom" constant="13" id="MqU-r8-9Cg"/>
+                                                <constraint firstAttribute="trailing" secondItem="ovY-ko-qAz" secondAttribute="trailing" constant="12" id="XTd-um-C4W"/>
+                                                <constraint firstItem="hqS-El-3QW" firstAttribute="top" secondItem="eux-uq-zld" secondAttribute="top" id="ePa-WF-sAT"/>
+                                                <constraint firstItem="hqS-El-3QW" firstAttribute="leading" secondItem="Hc8-Z8-qld" secondAttribute="leading" constant="12" id="j1b-Dx-sKI"/>
+                                                <constraint firstItem="eux-uq-zld" firstAttribute="top" secondItem="Hc8-Z8-qld" secondAttribute="top" constant="16" id="lff-Zi-f7k"/>
+                                                <constraint firstItem="mX6-pD-2mh" firstAttribute="top" secondItem="eux-uq-zld" secondAttribute="bottom" constant="13" id="ltX-QU-XNK"/>
+                                                <constraint firstItem="ZyK-e8-H3I" firstAttribute="leading" secondItem="Hc8-Z8-qld" secondAttribute="leading" constant="12" id="nSY-ol-MlL"/>
+                                                <constraint firstItem="mX6-pD-2mh" firstAttribute="leading" secondItem="Hc8-Z8-qld" secondAttribute="leading" constant="12" id="r6q-l2-iPt"/>
+                                                <constraint firstItem="ovY-ko-qAz" firstAttribute="top" secondItem="Hc8-Z8-qld" secondAttribute="top" constant="12" id="xpx-0W-ZBw"/>
+                                            </constraints>
+                                        </collectionViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <size key="customSize" width="414" height="128"/>
+                                        <connections>
+                                            <outlet property="issueNumber" destination="ovY-ko-qAz" id="2kE-2K-c3Z"/>
+                                            <outlet property="title" destination="mX6-pD-2mh" id="9qc-b5-eKh"/>
+                                            <outlet property="userId" destination="eux-uq-zld" id="Luh-Nf-w1H"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailIssueCell" id="alw-Lc-Rbv" customClass="DetailIssueCell" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="138" width="414" height="134"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="g1T-xM-Its">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="134"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.fill" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="blI-fe-Yo4">
+                                                    <rect key="frame" x="12" y="13.5" width="30" height="27"/>
+                                                    <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="30" id="ETi-da-qHC"/>
+                                                        <constraint firstAttribute="width" secondItem="blI-fe-Yo4" secondAttribute="height" multiplier="1:1" id="usr-8Q-Xri"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="8vT-sR-XCk">
+                                                    <rect key="frame" x="50" y="13" width="73.5" height="26.5"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="sample_id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rwt-TG-lGJ">
+                                                            <rect key="frame" x="0.0" y="0.0" width="73.5" height="13.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="16 minutes ago" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2eF-t5-efp">
+                                                            <rect key="frame" x="0.0" y="14.5" width="73.5" height="12"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="10"/>
+                                                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                    </subviews>
+                                                </stackView>
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="smiley" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="uFO-qI-F7u">
+                                                    <rect key="frame" x="12" y="113.5" width="20" height="15.5"/>
+                                                    <color key="tintColor" systemColor="systemGray2Color"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="uFO-qI-F7u" secondAttribute="height" multiplier="62:51" id="AKa-rJ-98v"/>
+                                                        <constraint firstAttribute="width" constant="20" id="cQf-Jx-gXB"/>
+                                                    </constraints>
+                                                </imageView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="587-eX-1u9">
+                                                    <rect key="frame" x="12" y="47" width="302" height="64"/>
+                                                    <string key="text">동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세동해물과 백두산이 마르고 닳도록 하느님이 보우하사 우리나라 만세 무궁화 삼천리 화려강산 대한사람 대한으로 길이 보전하세</string>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
+                                            <constraints>
+                                                <constraint firstItem="587-eX-1u9" firstAttribute="leading" secondItem="blI-fe-Yo4" secondAttribute="leading" id="32t-hc-sYN"/>
+                                                <constraint firstItem="blI-fe-Yo4" firstAttribute="leading" secondItem="g1T-xM-Its" secondAttribute="leading" constant="12" id="5MR-Go-gbu"/>
+                                                <constraint firstItem="uFO-qI-F7u" firstAttribute="top" secondItem="587-eX-1u9" secondAttribute="bottom" constant="2" id="7Sh-vh-Djg"/>
+                                                <constraint firstItem="8vT-sR-XCk" firstAttribute="leading" secondItem="blI-fe-Yo4" secondAttribute="trailing" constant="8" symbolic="YES" id="CEo-LE-AlL"/>
+                                                <constraint firstItem="blI-fe-Yo4" firstAttribute="width" secondItem="blI-fe-Yo4" secondAttribute="height" multiplier="1:1" id="E3P-Ez-2Vk"/>
+                                                <constraint firstItem="587-eX-1u9" firstAttribute="top" secondItem="blI-fe-Yo4" secondAttribute="bottom" constant="5" id="HKy-2Z-qcF"/>
+                                                <constraint firstItem="uFO-qI-F7u" firstAttribute="leading" secondItem="blI-fe-Yo4" secondAttribute="leading" id="MKc-hJ-OJe"/>
+                                                <constraint firstItem="8vT-sR-XCk" firstAttribute="top" secondItem="g1T-xM-Its" secondAttribute="top" constant="13" id="VbW-Qu-PZR"/>
+                                                <constraint firstAttribute="trailing" secondItem="587-eX-1u9" secondAttribute="trailing" constant="100" id="fUK-5L-Io9"/>
+                                                <constraint firstItem="blI-fe-Yo4" firstAttribute="top" secondItem="g1T-xM-Its" secondAttribute="top" constant="12" id="nQQ-fD-K6P"/>
+                                                <constraint firstAttribute="bottom" secondItem="uFO-qI-F7u" secondAttribute="bottom" constant="4.5" id="qC9-PE-ItC"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="414" height="128"/>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <size key="customSize" width="414" height="134"/>
                                         <connections>
-                                            <outlet property="label" destination="eux-uq-zld" id="B1k-Jv-OvV"/>
+                                            <outlet property="time" destination="2eF-t5-efp" id="sYF-Mb-R0K"/>
+                                            <outlet property="userId" destination="rwt-TG-lGJ" id="FhJ-m9-nss"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -70,8 +185,14 @@
         </scene>
     </scenes>
     <resources>
+        <image name="exclamationmark.circle" catalog="system" width="128" height="121"/>
+        <image name="person.fill" catalog="system" width="128" height="120"/>
+        <image name="smiley" catalog="system" width="128" height="121"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray2Color">
+            <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,15 +17,52 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="14K-Hj-Wjf">
-                                <rect key="frame" x="184" y="241" width="46" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button"/>
-                            </button>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="4Rk-L8-8qX">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="wUP-UH-h1f">
+                                    <size key="itemSize" width="414" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="DetailIssueCell" id="aom-T0-G8J" customClass="DetailIssueCell" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Hc8-Z8-qld">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eux-uq-zld">
+                                                    <rect key="frame" x="126" y="54" width="42" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </collectionViewCellContentView>
+                                        <size key="customSize" width="414" height="128"/>
+                                        <connections>
+                                            <outlet property="label" destination="eux-uq-zld" id="B1k-Jv-OvV"/>
+                                        </connections>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Jop-fU-krX"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="Jop-fU-krX" firstAttribute="trailing" secondItem="4Rk-L8-8qX" secondAttribute="trailing" id="7Y7-Kh-diS"/>
+                            <constraint firstItem="4Rk-L8-8qX" firstAttribute="top" secondItem="Jop-fU-krX" secondAttribute="top" id="EBa-3l-eIL"/>
+                            <constraint firstItem="4Rk-L8-8qX" firstAttribute="leading" secondItem="Jop-fU-krX" secondAttribute="leading" id="Zlr-Gr-wfO"/>
+                            <constraint firstItem="4Rk-L8-8qX" firstAttribute="bottom" secondItem="Jop-fU-krX" secondAttribute="bottom" id="bdC-ba-NbZ"/>
+                        </constraints>
                     </view>
+                    <connections>
+                        <outlet property="collectionView" destination="4Rk-L8-8qX" id="cGZ-eK-5cX"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="S8U-zN-FvY" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -161,7 +161,7 @@ final class DetailIssueListController: UIViewController {
     }
 }
 
-// MARK: collectionView 세팅
+// MARK: collectionView
 
 extension DetailIssueListController {
     
@@ -184,13 +184,10 @@ extension DetailIssueListController {
     }
     
     private func configureCollectionView() {
-        
         collectionView.collectionViewLayout = createLayout()
     }
     
     private func configureDataSource() {
-        
-        
         dataSource = UICollectionViewDiffableDataSource<Section, DetailIssueInfo>(collectionView: collectionView) {
             (collectionView, indexPath, item) -> UICollectionViewCell? in
             

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -39,9 +39,7 @@ final class DetailIssueListController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
-        dimmerView.isUserInteractionEnabled = false
-        dimmerView.alpha = 0
+        setUpDimmerView()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -59,6 +57,11 @@ final class DetailIssueListController: UIViewController {
     
     
     // MARK: - Method
+    
+    func setUpDimmerView() {
+        dimmerView.isUserInteractionEnabled = false
+        dimmerView.alpha = 0
+    }
     
     func setupCard() {
         tabBarController?.view.addSubview(dimmerView)

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -16,6 +16,10 @@ final class DetailIssueListController: UIViewController {
         case expanded
     }
     
+    enum Section {
+        case main
+    }
+    
     
     // MARK: - Property
     
@@ -33,6 +37,9 @@ final class DetailIssueListController: UIViewController {
     lazy var cardLatestY : CGFloat = cardEndY // 제스쳐 start 시 갱신되는 가장 최신의 Y 좌표
     var cardCurrentState: CardState = .collapsed
     
+    @IBOutlet weak var collectionView: UICollectionView!
+    var dataSource: UICollectionViewDiffableDataSource<Section, Int>! = nil
+    
     
     // MARK: - Life Cycle
     
@@ -40,6 +47,9 @@ final class DetailIssueListController: UIViewController {
         super.viewDidLoad()
         
         setUpDimmerView()
+        
+        configureHierarchy()
+        configureDataSource()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -152,3 +162,46 @@ final class DetailIssueListController: UIViewController {
     
 }
 
+extension DetailIssueListController {
+    private func createLayout() -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                             heightDimension: .fractionalHeight(1.0))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .fractionalWidth(0.2))
+        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+                                                         subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        return layout
+    }
+    
+    private func configureHierarchy() {
+        
+        collectionView.collectionViewLayout = createLayout()
+    }
+    private func configureDataSource() {
+        
+        
+        dataSource = UICollectionViewDiffableDataSource<Section, Int>(collectionView: collectionView) {
+            (collectionView: UICollectionView, indexPath: IndexPath, identifier: Int) -> UICollectionViewCell? in
+            
+            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DetailIssueCell.reuseIdentifier, for: indexPath) as? DetailIssueCell else {
+                fatalError("Cannot create new cell")
+            }
+            
+            DetailIssueCell.configureCell(cell: cell, data: "샘플")
+            
+            return cell
+        }
+
+        // initial data
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Int>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(Array(0..<5))
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -38,7 +38,7 @@ final class DetailIssueListController: UIViewController {
     var cardCurrentState: CardState = .collapsed
     
     @IBOutlet weak var collectionView: UICollectionView!
-    var dataSource: UICollectionViewDiffableDataSource<Section, Int>! = nil
+    var dataSource: UICollectionViewDiffableDataSource<Section, DetailIssueInfo>! = nil
     
     
     // MARK: - Life Cycle
@@ -48,7 +48,7 @@ final class DetailIssueListController: UIViewController {
         
         setUpDimmerView()
         
-        configureHierarchy()
+        configureCollectionView()
         configureDataSource()
     }
     
@@ -159,49 +159,69 @@ final class DetailIssueListController: UIViewController {
     
         frameAnimator.startAnimation()
     }
-    
 }
 
+// MARK: collectionView 세팅
+
 extension DetailIssueListController {
+    
     private func createLayout() -> UICollectionViewLayout {
-        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                             heightDimension: .fractionalHeight(1.0))
-        let item = NSCollectionLayoutItem(layoutSize: itemSize)
-
-        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
-                                              heightDimension: .fractionalWidth(0.2))
-        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
-                                                         subitems: [item])
-
-        let section = NSCollectionLayoutSection(group: group)
-
-        let layout = UICollectionViewCompositionalLayout(section: section)
-        return layout
+//        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+//                                             heightDimension: .fractionalHeight(1.0))
+//        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+//
+//        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+//                                              heightDimension: .fractionalWidth(0.2))
+//        let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize,
+//                                                         subitems: [item])
+//
+//        let section = NSCollectionLayoutSection(group: group)
+//
+//        let layout = UICollectionViewCompositionalLayout(section: section)
+//        return layout
+        let config = UICollectionLayoutListConfiguration(appearance: .insetGrouped)
+        return UICollectionViewCompositionalLayout.list(using: config)
     }
     
-    private func configureHierarchy() {
+    private func configureCollectionView() {
         
         collectionView.collectionViewLayout = createLayout()
     }
+    
     private func configureDataSource() {
         
         
-        dataSource = UICollectionViewDiffableDataSource<Section, Int>(collectionView: collectionView) {
-            (collectionView: UICollectionView, indexPath: IndexPath, identifier: Int) -> UICollectionViewCell? in
+        dataSource = UICollectionViewDiffableDataSource<Section, DetailIssueInfo>(collectionView: collectionView) {
+            (collectionView, indexPath, item) -> UICollectionViewCell? in
             
-            guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DetailIssueCell.reuseIdentifier, for: indexPath) as? DetailIssueCell else {
-                fatalError("Cannot create new cell")
+            switch indexPath.row {
+            case 0:
+                // TODO: 이 부분은 추후에 HeaderView 로 수정필요
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DetailIssueTopCell.reuseIdentifier, for: indexPath) as? DetailIssueTopCell else {
+                    fatalError("Cannot create new cell")
+                }
+                DetailIssueTopCell.configureCell(cell: cell, data: item)
+                return cell
+            default:
+                guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: DetailIssueCell.reuseIdentifier, for: indexPath) as? DetailIssueCell else {
+                    fatalError("Cannot create new cell")
+                }
+                DetailIssueCell.configureCell(cell: cell, data: item)
+                return cell
             }
-            
-            DetailIssueCell.configureCell(cell: cell, data: "샘플")
-            
-            return cell
         }
-
+        
+        let dummy = [DetailIssueInfo(id: 1, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플")),
+                     DetailIssueInfo(id: 2, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플")),
+                     DetailIssueInfo(id: 3, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플")),
+                     DetailIssueInfo(id: 4, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플")),
+                     DetailIssueInfo(id: 5, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플")),
+                     DetailIssueInfo(id: 6, content: "샘플", updateAt: "샘플", user: User(id: 1, userId: "샘플"))]
+        
         // initial data
-        var snapshot = NSDiffableDataSourceSnapshot<Section, Int>()
+        var snapshot = NSDiffableDataSourceSnapshot<Section, DetailIssueInfo>()
         snapshot.appendSections([.main])
-        snapshot.appendItems(Array(0..<5))
+        snapshot.appendItems(dummy)
         dataSource.apply(snapshot, animatingDifferences: false)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/DetailIssueInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/DetailIssueInfo.swift
@@ -1,0 +1,36 @@
+//
+//  DetailIssueIfno.swift
+//  IssueTracker
+//
+//  Created by a1111 on 2020/11/05.
+//
+
+import Foundation
+
+struct DetailIssueInfo: Codable, Hashable {
+    let id: Int
+    let content: String
+    let updateAt: String
+    let user: User
+    
+    static func == (lhs: DetailIssueInfo, rhs: DetailIssueInfo) -> Bool {
+        return lhs.id == rhs.id
+    }
+    
+    enum CodingKeys: String, CodingKey {
+        case id, content
+        case updateAt = "update_at"
+        case user
+    }
+}
+
+struct User: Codable, Hashable {
+    let id: Int
+    let userId: String
+    
+    enum CodingKeys: String, CodingKey {
+        case id
+        case userId = "user_id"
+    }
+}
+

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
@@ -9,32 +9,16 @@ import Foundation
 
 struct Comment: Codable {
     let id: Int
-    let content, createdAt, updatedAt: String
-    let deletedAt: String?
-    let userID, issueID: Int
-    let mentions: Mentions
+    let content, createdAt, updatedAt: String?
+    let userID: Int
+    let mentions: Assignee
 
     enum CodingKeys: String, CodingKey {
-        case id, content, createdAt, updatedAt, deletedAt
+        case id, content
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
         case userID = "user_id"
-        case issueID = "issue_id"
         case mentions
     }
 }
 
-struct Mentions: Codable {
-    let id: Int
-    let userID: String
-    let password, photoURL: String?
-    let type: String
-    let createdAt, updatedAt: String
-    let deletedAt: String?
-
-    enum CodingKeys: String, CodingKey {
-        case id
-        case userID = "user_id"
-        case password
-        case photoURL = "photo_url"
-        case type, createdAt, updatedAt, deletedAt
-    }
-}

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueData.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueData.swift
@@ -12,7 +12,7 @@ struct IssueData: Codable {
     let id: Int
     let title: String
     let status: String
-    let createdAt: String
+    let createdAt: String?
     let updatedAt: String?
     let deletedAt: String?
     let userID: Int?

--- a/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
@@ -1,0 +1,33 @@
+//
+//  DetailIssueCell.swift
+//  IssueTracker
+//
+//  Created by a1111 on 2020/11/05.
+//
+
+import UIKit
+
+final class DetailIssueCell: UICollectionViewCell {
+    
+    static let reuseIdentifier = String(describing: DetailIssueCell.self)
+    @IBOutlet weak var label: UILabel!
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+    }
+    
+    static func configureCell(cell: DetailIssueCell, data: String) {
+        
+        cell.label.text = data
+        
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
@@ -7,10 +7,13 @@
 
 import UIKit
 
-final class DetailIssueHeaderCell: UICollectionViewCell {
+final class DetailIssueTopCell: UICollectionViewCell {
     
-    static let reuseIdentifier = String(describing: DetailIssueCell.self)
-    @IBOutlet weak var label: UILabel!
+    static let reuseIdentifier = String(describing: DetailIssueTopCell.self)
+    @IBOutlet weak var userId: UILabel!
+    @IBOutlet weak var title: UILabel!
+    @IBOutlet weak var issueNumber: UILabel!
+    
     
     // MARK: - Initializer
     
@@ -24,19 +27,20 @@ final class DetailIssueHeaderCell: UICollectionViewCell {
         
     }
     
-    static func configureCell(cell: DetailIssueCell, data: DetailIssueInfo) {
+    static func configureCell(cell: DetailIssueTopCell, data: DetailIssueInfo) {
         
-        cell.label.text = data.name
-        
+        cell.userId.text = "sampleId"
+        cell.title.text = "곧 완성될 제목"
     }
-    
 }
 
 
-final class DetailIssueHeaderCell: UICollectionViewCell {
+final class DetailIssueCell: UICollectionViewCell {
     
     static let reuseIdentifier = String(describing: DetailIssueCell.self)
-    @IBOutlet weak var label: UILabel!
+    @IBOutlet weak var userId: UILabel!
+    @IBOutlet weak var time: UILabel!
+    @IBOutlet weak var content: UITextView!
     
     // MARK: - Initializer
     
@@ -52,7 +56,7 @@ final class DetailIssueHeaderCell: UICollectionViewCell {
     
     static func configureCell(cell: DetailIssueCell, data: DetailIssueInfo) {
         
-        cell.label.text = data.name
+        cell.userId.text = "sample_id2"
         
     }
     

--- a/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/DetailIssueCell.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-final class DetailIssueCell: UICollectionViewCell {
+final class DetailIssueHeaderCell: UICollectionViewCell {
     
     static let reuseIdentifier = String(describing: DetailIssueCell.self)
     @IBOutlet weak var label: UILabel!
@@ -24,9 +24,35 @@ final class DetailIssueCell: UICollectionViewCell {
         
     }
     
-    static func configureCell(cell: DetailIssueCell, data: String) {
+    static func configureCell(cell: DetailIssueCell, data: DetailIssueInfo) {
         
-        cell.label.text = data
+        cell.label.text = data.name
+        
+    }
+    
+}
+
+
+final class DetailIssueHeaderCell: UICollectionViewCell {
+    
+    static let reuseIdentifier = String(describing: DetailIssueCell.self)
+    @IBOutlet weak var label: UILabel!
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+    }
+    
+    static func configureCell(cell: DetailIssueCell, data: DetailIssueInfo) {
+        
+        cell.label.text = data.name
         
     }
     


### PR DESCRIPTION
# 작성자와 제목, 오픈 여부, 이슈번호(#1)를 형식으로 볼 수 있다

## 해당 이슈 📎

#108 - 작성자와 제목, 오픈 여부, 이슈번호(#1)를 형식으로 볼 수 있다

## 변경 사항 🛠
- Compositional layout + Diffable Datasource 컬렉션뷰로 목록 구현
- 관련 데이터객체 구현
- 작성자/제목/오픈여부/이슈 번호를 보여주는 cell 구현

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

1. 결국 Compositional layout + DiffableDatasource 를 이용하여 구현했습니다. ㅋㅋㅋ 처음에 어떻게 쓰는건지 몰라서 헤맸네요.
Compositional layout 중에 tableview 와 유사한 디자인을 제공하는 UICollectionViewLayoutListConfiguration 을 사용했습니다.

2. 디자인은 다음에 백엔드 api 랑 연결할 때 issue 파서 다시 개선하겠습니다 ㅎㅎ

<img width="500" alt="스크린샷 2020-11-05 오후 6 46 22" src="https://user-images.githubusercontent.com/20080283/98224898-6500b500-1f97-11eb-8c42-a828ad0be345.png">
