### PR TITLE
마일스톤 관리 화면으로 갈 수 있다

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -73,6 +73,8 @@
 		718C38932553E6FB002E4903 /* ManageMilestoneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */; };
 		718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38972553E716002E4903 /* ManageMilestoneModalView.swift */; };
 		718C389D2553E72E002E4903 /* ManageMilestoneModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C389C2553E72E002E4903 /* ManageMilestoneModalViewController.swift */; };
+		718C38A52553FC3F002E4903 /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38A42553FC3F002E4903 /* String+.swift */; };
+		718C38AA2553FC5C002E4903 /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38A92553FC5C002E4903 /* UITextField+.swift */; };
 		719453B3254AAF6600A5864E /* IssueList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 719453B2254AAF6600A5864E /* IssueList.storyboard */; };
 		71969BDE25510D4F00C96CE2 /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = 71969BDD25510D4F00C96CE2 /* MarkdownView */; };
 /* End PBXBuildFile section */
@@ -165,6 +167,8 @@
 		718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneViewController.swift; sourceTree = "<group>"; };
 		718C38972553E716002E4903 /* ManageMilestoneModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneModalView.swift; sourceTree = "<group>"; };
 		718C389C2553E72E002E4903 /* ManageMilestoneModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneModalViewController.swift; sourceTree = "<group>"; };
+		718C38A42553FC3F002E4903 /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
+		718C38A92553FC5C002E4903 /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		719453B2254AAF6600A5864E /* IssueList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = IssueList.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -512,6 +516,8 @@
 				3393E0AB2552698C003DCDA4 /* UIView+.swift */,
 				333FE2982551214A000C0F0B /* RegParser.swift */,
 				7130A6CB2552A2A700EE2141 /* UIColor+.swift */,
+				718C38A42553FC3F002E4903 /* String+.swift */,
+				718C38A92553FC5C002E4903 /* UITextField+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -680,12 +686,14 @@
 				3328A979254B14F600126761 /* EndPointable.swift in Sources */,
 				3358A5BA254FE5AD008CEFA3 /* AssigneesInfo.swift in Sources */,
 				33375C872547F34A00E8A8E8 /* BackEndOAuthManager.swift in Sources */,
+				718C38AA2553FC5C002E4903 /* UITextField+.swift in Sources */,
 				3358A56C254D1C95008CEFA3 /* GithubAPIManager.swift in Sources */,
 				33375CB12548595700E8A8E8 /* OAuthManager.swift in Sources */,
 				33375C3A2547E70E00E8A8E8 /* AppDelegate.swift in Sources */,
 				712CBEA6255008B700E8F95F /* RegisterIssueViewController.swift in Sources */,
 				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				333FE2AA25515167000C0F0B /* DetailIssueListController.swift in Sources */,
+				718C38A52553FC3F002E4903 /* String+.swift in Sources */,
 				7130A6A025527E8900EE2141 /* ManageLabelModalView.swift in Sources */,
 				7130A69525516AC500EE2141 /* ManageLabelViewController.swift in Sources */,
 				3322CF7E25539E3B0022ABA6 /* Comment.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -69,6 +69,10 @@
 		7130A6D12552CD0F00EE2141 /* InputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7130A6D02552CD0F00EE2141 /* InputValidator.swift */; };
 		71531F57254A859F00CCFAE2 /* IssueListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71531F56254A859F00CCFAE2 /* IssueListViewController.swift */; };
 		71531F60254A88F000CCFAE2 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71531F5F254A88F000CCFAE2 /* UIButton+.swift */; };
+		718C388E2553E6E1002E4903 /* ManageMilestone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 718C388D2553E6E1002E4903 /* ManageMilestone.storyboard */; };
+		718C38932553E6FB002E4903 /* ManageMilestoneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */; };
+		718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38972553E716002E4903 /* ManageMilestoneModalView.swift */; };
+		718C389D2553E72E002E4903 /* ManageMilestoneModalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C389C2553E72E002E4903 /* ManageMilestoneModalViewController.swift */; };
 		719453B3254AAF6600A5864E /* IssueList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 719453B2254AAF6600A5864E /* IssueList.storyboard */; };
 		71969BDE25510D4F00C96CE2 /* MarkdownView in Frameworks */ = {isa = PBXBuildFile; productRef = 71969BDD25510D4F00C96CE2 /* MarkdownView */; };
 /* End PBXBuildFile section */
@@ -157,6 +161,10 @@
 		7130A6D02552CD0F00EE2141 /* InputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputValidator.swift; sourceTree = "<group>"; };
 		71531F56254A859F00CCFAE2 /* IssueListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListViewController.swift; sourceTree = "<group>"; };
 		71531F5F254A88F000CCFAE2 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
+		718C388D2553E6E1002E4903 /* ManageMilestone.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ManageMilestone.storyboard; sourceTree = "<group>"; };
+		718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneViewController.swift; sourceTree = "<group>"; };
+		718C38972553E716002E4903 /* ManageMilestoneModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneModalView.swift; sourceTree = "<group>"; };
+		718C389C2553E72E002E4903 /* ManageMilestoneModalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneModalViewController.swift; sourceTree = "<group>"; };
 		719453B2254AAF6600A5864E /* IssueList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = IssueList.storyboard; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -271,6 +279,7 @@
 		33375C6F2547EC7C00E8A8E8 /* Controller */ = {
 			isa = PBXGroup;
 			children = (
+				718C388C2553E6D2002E4903 /* ManageMilestone */,
 				712CBE9F255002D100E8F95F /* RegisterIssue */,
 				7130A68E2551636900EE2141 /* ManageLabel */,
 				3358A589254EDEDA008CEFA3 /* SignIn */,
@@ -483,8 +492,8 @@
 				712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */,
 			);
 			path = RegisterIssue;
-               sourceTree = "<group>";
-        };
+			sourceTree = "<group>";
+		};
 		7130A68E2551636900EE2141 /* ManageLabel */ = {
 			isa = PBXGroup;
 			children = (
@@ -505,6 +514,17 @@
 				7130A6CB2552A2A700EE2141 /* UIColor+.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		718C388C2553E6D2002E4903 /* ManageMilestone */ = {
+			isa = PBXGroup;
+			children = (
+				718C388D2553E6E1002E4903 /* ManageMilestone.storyboard */,
+				718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */,
+				718C38972553E716002E4903 /* ManageMilestoneModalView.swift */,
+				718C389C2553E72E002E4903 /* ManageMilestoneModalViewController.swift */,
+			);
+			path = ManageMilestone;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -618,6 +638,7 @@
 			files = (
 				719453B3254AAF6600A5864E /* IssueList.storyboard in Resources */,
 				33151F2725499E04006B94A9 /* NanumSquareBold.ttf in Resources */,
+				718C388E2553E6E1002E4903 /* ManageMilestone.storyboard in Resources */,
 				3393E09A25523D38003DCDA4 /* CardView.xib in Resources */,
 				7130A690255163A700EE2141 /* ManageLabel.storyboard in Resources */,
 				3358A581254ED7D3008CEFA3 /* Filter.storyboard in Resources */,
@@ -663,13 +684,13 @@
 				33375CB12548595700E8A8E8 /* OAuthManager.swift in Sources */,
 				33375C3A2547E70E00E8A8E8 /* AppDelegate.swift in Sources */,
 				712CBEA6255008B700E8F95F /* RegisterIssueViewController.swift in Sources */,
-				33375CB725487A1700E8A8E8 /* AppleSignInButton.swift in Sources */,
-				3358A57C254ED757008CEFA3 /* StoryboardName.swift in Sources */,
+				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				333FE2AA25515167000C0F0B /* DetailIssueListController.swift in Sources */,
 				7130A6A025527E8900EE2141 /* ManageLabelModalView.swift in Sources */,
 				7130A69525516AC500EE2141 /* ManageLabelViewController.swift in Sources */,
 				3322CF7E25539E3B0022ABA6 /* Comment.swift in Sources */,
 				3358A593254EEBDF008CEFA3 /* DetailConditionTableViewController.swift in Sources */,
+				718C389D2553E72E002E4903 /* ManageMilestoneModalViewController.swift in Sources */,
 				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				3393E0AC2552698C003DCDA4 /* UIView+.swift in Sources */,
 				3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */,
@@ -686,6 +707,7 @@
 				3358A5B2254FE462008CEFA3 /* MilestonesInfo.swift in Sources */,
 				3328A97F254B155000126761 /* GithubAPI.swift in Sources */,
 				33151F3E254A6464006B94A9 /* FilteringController.swift in Sources */,
+				718C38932553E6FB002E4903 /* ManageMilestoneViewController.swift in Sources */,
 				33BD8DD3254989E100537960 /* NotificationName.swift in Sources */,
 				33375C3C2547E70E00E8A8E8 /* SceneDelegate.swift in Sources */,
 				33BD8DE62549956B00537960 /* BackEndAPIManager.swift in Sources */,
@@ -695,6 +717,7 @@
 				7130A6D12552CD0F00EE2141 /* InputValidator.swift in Sources */,
 				339892B22549876B00D9FB63 /* UserInfo.swift in Sources */,
 				7130A6CC2552A2A700EE2141 /* UIColor+.swift in Sources */,
+				718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */,
 				3322CFA52553B8810022ABA6 /* AppleSignInButton.swift in Sources */,
 				3322CFAA2553B8900022ABA6 /* AppleSignInButton.swift in Sources */,
 				339892A125497CB400D9FB63 /* UserDefault.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Image references" minToolsVersion="12.0"/>
@@ -15,11 +15,11 @@
             <objects>
                 <viewController id="Euh-Aj-MVR" customClass="ManageLabelViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="P0m-Kh-sVU">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="MJS-qW-swq">
-                                <rect key="frame" x="0.0" y="44" width="375" height="574"/>
+                                <rect key="frame" x="0.0" y="140" width="375" height="589"/>
                                 <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Dxb-yR-UoN">
                                     <size key="itemSize" width="414" height="71"/>
@@ -29,7 +29,7 @@
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="LabelCell" id="Zk9-Tj-K1Z" customClass="LabelCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="-19.5" y="0.0" width="414" height="71"/>
+                                        <rect key="frame" x="-19.666666666666668" y="0.0" width="414" height="71"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="UF6-bU-t1H">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="71"/>
@@ -125,11 +125,11 @@
             <objects>
                 <viewController id="jRf-jR-yWq" customClass="ManageLabelModalViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="V2h-Kq-Eu5">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BYL-Yp-ZM3" customClass="ManageLabelModalView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="20" y="118.5" width="335" height="340"/>
+                                <rect key="frame" x="20" y="191" width="335" height="340"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="DFK-Km-AbT">
                                         <rect key="frame" x="14" y="10" width="30" height="34"/>
@@ -151,12 +151,12 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이곳에 레이블 이름을 작성해주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="zC0-Od-wou" userLabel="firstTextField">
-                                        <rect key="frame" x="78" y="92" width="217" height="18.5"/>
+                                        <rect key="frame" x="78" y="92" width="217" height="18.666666666666671"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이곳에 레이블 설명을 적어주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="qia-KK-9cc" userLabel="secondTextField">
-                                        <rect key="frame" x="78" y="165.5" width="217" height="18.5"/>
+                                        <rect key="frame" x="78" y="165.66666666666669" width="217" height="18.333333333333343"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
@@ -181,25 +181,25 @@
                                         </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EUa-gC-Eon" userLabel="firstTextFieldLabel">
-                                        <rect key="frame" x="35" y="91" width="30" height="21"/>
+                                        <rect key="frame" x="35" y="90.666666666666686" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6MT-0W-J90" userLabel="secondTextFieldLabel">
-                                        <rect key="frame" x="35" y="164.5" width="30" height="21"/>
+                                        <rect key="frame" x="35" y="164.33333333333331" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="색상" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SsU-Zp-KYL" userLabel="thirdTextFieldLabel">
-                                        <rect key="frame" x="35" y="238" width="29.5" height="21"/>
+                                        <rect key="frame" x="35" y="237.66666666666669" width="29.666666666666671" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="예) #FF9500" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="byM-5n-DR0" userLabel="thirdTextField">
-                                        <rect key="frame" x="77.5" y="239" width="80" height="18.5"/>
+                                        <rect key="frame" x="77.666666666666671" y="239" width="80.000000000000014" height="18.666666666666686"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="80" id="Dop-OO-tI6"/>
                                         </constraints>
@@ -207,7 +207,7 @@
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NT5-s6-sH4">
-                                        <rect key="frame" x="20" y="124.5" width="295" height="1"/>
+                                        <rect key="frame" x="20" y="124.66666666666669" width="295" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="RDv-n0-cvd"/>
@@ -227,7 +227,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JzE-sC-cQN">
-                                        <rect key="frame" x="20" y="271.5" width="295" height="1"/>
+                                        <rect key="frame" x="20" y="271.66666666666669" width="295" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="Dcr-kr-FrB"/>
@@ -237,7 +237,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Du1-P2-5kw">
-                                        <rect key="frame" x="290" y="236" width="25" height="25"/>
+                                        <rect key="frame" x="290" y="235.66666666666669" width="25" height="25"/>
                                         <color key="backgroundColor" systemColor="systemGray2Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="25" id="BL5-SZ-UoF"/>
@@ -258,7 +258,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="MXm-NN-wIO" userLabel="colorButton">
-                                        <rect key="frame" x="190" y="233.5" width="80" height="30"/>
+                                        <rect key="frame" x="190" y="233.33333333333331" width="80" height="30"/>
                                         <color key="backgroundColor" systemColor="systemOrangeColor"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="30" id="RcH-Ff-kBa"/>
@@ -290,7 +290,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HQi-VY-ucM">
-                                        <rect key="frame" x="30" y="206.5" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="30" y="206.66666666666669" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -390,7 +390,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="jEl-XB-ON9">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabelModalViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabelModalViewController.swift
@@ -199,13 +199,3 @@ extension ManageLabelModalViewController: UIColorPickerViewControllerDelegate {
         thirdTextField.text = viewController.selectedColor.toHex
     }
 }
-
-// MARK: - Validation 로직을 사용하기 위한 익스텐션
-extension UITextField {
-    @discardableResult
-    func validatedText(validationType: ValidatorType) throws -> String {
-        
-        let validator = ValidatorFactory.validatorFor(type: validationType)
-        return try validator.validate(self.text!)
-    }
-}

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
@@ -1,7 +1,294 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="collection view cell content view" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--마일스톤-->
+        <scene sceneID="8jE-eh-h63">
+            <objects>
+                <viewController id="BEF-ob-tcE" customClass="ManageMilestoneViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="2QD-jL-Dae">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="w8F-kl-Cek">
+                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ojs-bW-NQr">
+                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                                    <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                                    <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                                </collectionViewFlowLayout>
+                                <cells>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="hgV-OZ-1zA">
+                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Jjk-yG-MXh">
+                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </collectionViewCellContentView>
+                                    </collectionViewCell>
+                                </cells>
+                            </collectionView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="Fdc-il-ex1"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="w8F-kl-Cek" firstAttribute="leading" secondItem="Fdc-il-ex1" secondAttribute="leading" id="J51-Qv-xay"/>
+                            <constraint firstItem="Fdc-il-ex1" firstAttribute="bottom" secondItem="w8F-kl-Cek" secondAttribute="bottom" id="Ynb-B2-T7e"/>
+                            <constraint firstItem="Fdc-il-ex1" firstAttribute="trailing" secondItem="w8F-kl-Cek" secondAttribute="trailing" id="kEw-Fj-7KE"/>
+                            <constraint firstItem="w8F-kl-Cek" firstAttribute="top" secondItem="Fdc-il-ex1" secondAttribute="top" id="mT1-QG-mga"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" title="마일스톤" id="UVE-O6-1dW">
+                        <barButtonItem key="rightBarButtonItem" image="plus" catalog="system" id="ffr-VY-6sb">
+                            <connections>
+                                <segue destination="YwG-UJ-Jsn" kind="presentation" modalPresentationStyle="overFullScreen" id="6PW-jG-3aT"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="fyr-TC-3si" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1042.0289855072465" y="95.758928571428569"/>
+        </scene>
+        <!--Manage Milestone Modal View Controller-->
+        <scene sceneID="zKO-LY-h6Q">
+            <objects>
+                <viewController id="YwG-UJ-Jsn" customClass="ManageMilestoneModalViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Aea-Pi-UXB">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mbw-83-YwP" customClass="ManageMilestoneModalView" customModule="IssueTracker" customModuleProvider="target">
+                                <rect key="frame" x="45.5" y="233" width="323.5" height="340"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vFw-ux-Z1T">
+                                        <rect key="frame" x="14" y="10" width="30" height="34"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <state key="normal" image="xmark" catalog="system"/>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PbB-f3-dcW">
+                                        <rect key="frame" x="0.0" y="51" width="323.5" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="nZx-Sd-2wh"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이곳에 마일스톤 이름을 작성해주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Ch-YB-FAy" userLabel="firstTextField">
+                                        <rect key="frame" x="78" y="92" width="205.5" height="18.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="yyyy-mm-dd (선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bKf-57-VNC" userLabel="secondTextField">
+                                        <rect key="frame" x="77.5" y="165.5" width="206" height="18.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CnQ-YB-YHE">
+                                        <rect key="frame" x="238.5" y="288" width="70" height="42"/>
+                                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="42" id="noE-Fe-8WC"/>
+                                            <constraint firstAttribute="width" constant="70" id="wYE-AW-Wy4"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <state key="normal" title="저장">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                <real key="value" value="10"/>
+                                            </userDefinedRuntimeAttribute>
+                                        </userDefinedRuntimeAttributes>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="omN-1U-Poc" userLabel="firstTextFieldLabel">
+                                        <rect key="frame" x="35" y="91" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sVW-2Z-cLe" userLabel="secondTextFieldLabel">
+                                        <rect key="frame" x="35" y="149" width="29.5" height="42"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="42" id="PVd-ug-ey6"/>
+                                            <constraint firstAttribute="width" constant="29.5" id="kKq-9S-qVm"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c8f-bV-zKa" userLabel="thirdTextFieldLabel">
+                                        <rect key="frame" x="35" y="238" width="30" height="21"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이번 배포를 위한 스프린트 (선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bec-z9-lLM" userLabel="thirdTextField">
+                                        <rect key="frame" x="78" y="239" width="205.5" height="18.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                    </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ih-ju-5c6">
+                                        <rect key="frame" x="20" y="124.5" width="283.5" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="uui-mX-wsS"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPz-Ns-JtT">
+                                        <rect key="frame" x="20" y="198" width="283.5" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="a8p-gI-LIt"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Kn-ty-Eba">
+                                        <rect key="frame" x="20" y="271.5" width="283.5" height="1"/>
+                                        <color key="backgroundColor" systemColor="systemGray5Color"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="1" id="61v-qi-MU3"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8o8-yK-tCi">
+                                        <rect key="frame" x="20" y="297" width="34" height="28"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                        <state key="normal" title="초기화">
+                                            <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                    </button>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rc7-xY-dNr">
+                                        <rect key="frame" x="30" y="133" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tFv-um-sId">
+                                        <rect key="frame" x="30" y="206.5" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4z-IZ-nHz">
+                                        <rect key="frame" x="30" y="280" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <constraints>
+                                    <constraint firstItem="c8f-bV-zKa" firstAttribute="centerY" secondItem="Bec-z9-lLM" secondAttribute="centerY" id="23b-05-hOq"/>
+                                    <constraint firstItem="c8f-bV-zKa" firstAttribute="leading" secondItem="1Kn-ty-Eba" secondAttribute="leading" constant="15" id="291-Zq-894"/>
+                                    <constraint firstItem="bKf-57-VNC" firstAttribute="trailing" secondItem="IPz-Ns-JtT" secondAttribute="trailing" constant="-20" id="2fi-eM-Brd"/>
+                                    <constraint firstAttribute="bottom" secondItem="8o8-yK-tCi" secondAttribute="bottom" constant="15" id="4UF-eM-K1A"/>
+                                    <constraint firstItem="Bec-z9-lLM" firstAttribute="leading" secondItem="c8f-bV-zKa" secondAttribute="trailing" constant="13" id="5Kr-IG-TDy"/>
+                                    <constraint firstItem="B4z-IZ-nHz" firstAttribute="leading" secondItem="1Kn-ty-Eba" secondAttribute="leading" constant="10" id="8qP-8z-aEM"/>
+                                    <constraint firstItem="tFv-um-sId" firstAttribute="top" secondItem="IPz-Ns-JtT" secondAttribute="bottom" constant="7.5" id="994-CB-hau"/>
+                                    <constraint firstItem="bKf-57-VNC" firstAttribute="top" secondItem="1Ch-YB-FAy" secondAttribute="bottom" constant="55" id="9Hb-bf-gF6"/>
+                                    <constraint firstItem="Bec-z9-lLM" firstAttribute="top" secondItem="bKf-57-VNC" secondAttribute="bottom" constant="55" id="AnV-3F-x4l"/>
+                                    <constraint firstItem="IPz-Ns-JtT" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" id="BO0-72-97G"/>
+                                    <constraint firstItem="1Ch-YB-FAy" firstAttribute="top" secondItem="PbB-f3-dcW" secondAttribute="bottom" constant="40" id="BrV-fn-rJ8"/>
+                                    <constraint firstItem="1Ch-YB-FAy" firstAttribute="trailing" secondItem="6Ih-ju-5c6" secondAttribute="trailing" constant="-20" id="Bzv-HU-OZG"/>
+                                    <constraint firstItem="PbB-f3-dcW" firstAttribute="top" secondItem="mbw-83-YwP" secondAttribute="top" constant="51" id="FDj-Ig-d6d"/>
+                                    <constraint firstAttribute="trailing" secondItem="CnQ-YB-YHE" secondAttribute="trailing" constant="15" id="GL4-ls-q2v"/>
+                                    <constraint firstItem="6Ih-ju-5c6" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" id="Kcl-mo-scG"/>
+                                    <constraint firstItem="bKf-57-VNC" firstAttribute="bottom" secondItem="IPz-Ns-JtT" secondAttribute="bottom" constant="-15" id="PWP-V0-lKu"/>
+                                    <constraint firstAttribute="trailing" secondItem="PbB-f3-dcW" secondAttribute="trailing" id="QXr-UK-Fcu"/>
+                                    <constraint firstAttribute="trailing" secondItem="1Kn-ty-Eba" secondAttribute="trailing" constant="20" id="Rjy-vI-gde"/>
+                                    <constraint firstItem="tFv-um-sId" firstAttribute="leading" secondItem="IPz-Ns-JtT" secondAttribute="leading" constant="10" id="Uiv-ua-3bF"/>
+                                    <constraint firstItem="B4z-IZ-nHz" firstAttribute="top" secondItem="1Kn-ty-Eba" secondAttribute="bottom" constant="7.5" id="VNh-wu-5GH"/>
+                                    <constraint firstItem="rc7-xY-dNr" firstAttribute="top" secondItem="6Ih-ju-5c6" secondAttribute="bottom" constant="7.5" id="VwE-kl-uNs"/>
+                                    <constraint firstItem="rc7-xY-dNr" firstAttribute="leading" secondItem="6Ih-ju-5c6" secondAttribute="leading" constant="10" id="ZqR-zG-hz9"/>
+                                    <constraint firstItem="1Kn-ty-Eba" firstAttribute="bottom" secondItem="Bec-z9-lLM" secondAttribute="bottom" constant="15" id="aCb-cN-3Lb"/>
+                                    <constraint firstItem="Bec-z9-lLM" firstAttribute="trailing" secondItem="1Kn-ty-Eba" secondAttribute="trailing" constant="-20" id="cWX-Xb-qdk"/>
+                                    <constraint firstItem="PbB-f3-dcW" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" id="elP-L4-x7P"/>
+                                    <constraint firstAttribute="trailing" secondItem="IPz-Ns-JtT" secondAttribute="trailing" constant="20" id="f1s-la-84D"/>
+                                    <constraint firstItem="1Kn-ty-Eba" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" id="gfN-ZC-6Wu"/>
+                                    <constraint firstItem="sVW-2Z-cLe" firstAttribute="centerY" secondItem="bKf-57-VNC" secondAttribute="centerY" constant="-5" id="krx-sf-g44"/>
+                                    <constraint firstItem="bKf-57-VNC" firstAttribute="leading" secondItem="sVW-2Z-cLe" secondAttribute="trailing" constant="13" id="lEF-9L-Edd"/>
+                                    <constraint firstAttribute="bottom" secondItem="CnQ-YB-YHE" secondAttribute="bottom" constant="10" id="pIK-eY-ZPd"/>
+                                    <constraint firstAttribute="height" constant="340" id="ptV-TO-Y8s"/>
+                                    <constraint firstAttribute="trailing" secondItem="6Ih-ju-5c6" secondAttribute="trailing" constant="20" id="qwu-UF-ucl"/>
+                                    <constraint firstItem="6Ih-ju-5c6" firstAttribute="bottom" secondItem="1Ch-YB-FAy" secondAttribute="bottom" constant="15" id="rAD-Aj-jkC"/>
+                                    <constraint firstItem="sVW-2Z-cLe" firstAttribute="leading" secondItem="IPz-Ns-JtT" secondAttribute="leading" constant="15" id="rgW-uz-PiL"/>
+                                    <constraint firstItem="omN-1U-Poc" firstAttribute="centerY" secondItem="1Ch-YB-FAy" secondAttribute="centerY" id="spu-0n-lX4"/>
+                                    <constraint firstItem="1Ch-YB-FAy" firstAttribute="leading" secondItem="omN-1U-Poc" secondAttribute="trailing" constant="13" id="wJA-bX-MaB"/>
+                                    <constraint firstItem="8o8-yK-tCi" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" symbolic="YES" id="xgT-XM-QWO"/>
+                                    <constraint firstItem="omN-1U-Poc" firstAttribute="leading" secondItem="6Ih-ju-5c6" secondAttribute="leading" constant="15" id="yra-UU-rx8"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="10"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="7GD-1C-yxk"/>
+                        <color key="backgroundColor" red="0.46570028297149824" green="0.46625122591040641" blue="0.5" alpha="0.5" colorSpace="custom" customColorSpace="displayP3"/>
+                        <constraints>
+                            <constraint firstItem="mbw-83-YwP" firstAttribute="centerX" secondItem="Aea-Pi-UXB" secondAttribute="centerX" id="Lee-9J-w44"/>
+                            <constraint firstItem="mbw-83-YwP" firstAttribute="centerY" secondItem="Aea-Pi-UXB" secondAttribute="centerY" constant="-45" id="vzH-7h-8eU"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xkc-gV-fXF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1882.608695652174" y="95.758928571428569"/>
+        </scene>
+        <!--마일스톤-->
+        <scene sceneID="8si-Qc-XRH">
+            <objects>
+                <navigationController storyboardIdentifier="ManageMilestoneInitialController" automaticallyAdjustsScrollViewInsets="NO" id="z6E-1z-clE" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="마일스톤" image="3.circle.fill" catalog="system" id="dKn-e5-lua"/>
+                    <toolbarItems/>
+                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="1mT-sv-gtf">
+                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BEF-ob-tcE" kind="relationship" relationship="rootViewController" id="B9e-R4-C3Q"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Tkk-gM-VYs" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="131.8840579710145" y="95.758928571428569"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="3.circle.fill" catalog="system" width="128" height="121"/>
+        <image name="plus" catalog="system" width="128" height="113"/>
+        <image name="xmark" catalog="system" width="128" height="113"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemGray5Color">
+            <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
@@ -14,26 +14,107 @@
             <objects>
                 <viewController id="BEF-ob-tcE" customClass="ManageMilestoneViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="2QD-jL-Dae">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="w8F-kl-Cek">
-                                <rect key="frame" x="0.0" y="88" width="414" height="725"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <rect key="frame" x="0.0" y="140" width="375" height="589"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" automaticEstimatedItemSize="YES" minimumLineSpacing="10" minimumInteritemSpacing="10" id="ojs-bW-NQr">
-                                    <size key="itemSize" width="128" height="128"/>
+                                    <size key="itemSize" width="413" height="82"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
-                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" id="hgV-OZ-1zA">
-                                        <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="MilestoneCell" id="hgV-OZ-1zA" customClass="MilestoneCell" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="-19" y="0.0" width="413" height="82"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="Jjk-yG-MXh">
-                                            <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="413" height="82"/>
                                             <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="RwH-yC-dmP">
+                                                    <rect key="frame" x="20" y="13" width="73" height="20"/>
+                                                    <accessibility key="accessibilityConfiguration">
+                                                        <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
+                                                    </accessibility>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="20" id="KV6-p4-Btb"/>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="73" id="biO-YG-bfH"/>
+                                                    </constraints>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <state key="normal" title="스프린트 2">
+                                                        <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </state>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                                            <real key="value" value="1"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                            <real key="value" value="7"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                                            <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
+                                                </button>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2020년 6월 19일까지" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E8w-iB-xuz">
+                                                    <rect key="frame" x="108" y="16" width="109.5" height="14"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="64%" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rSR-eL-HN5">
+                                                    <rect key="frame" x="371" y="11" width="34" height="17"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="14"/>
+                                                    <color key="textColor" red="0.18128351337228746" green="0.41862635458669351" blue="0.18359765401678529" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="13 open" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2bC-bX-PVa">
+                                                    <rect key="frame" x="358.5" y="39" width="47.5" height="14.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="23 closed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pt5-pb-KY7">
+                                                    <rect key="frame" x="347" y="54.5" width="59" height="14.5"/>
+                                                    <fontDescription key="fontDescription" type="boldSystem" pointSize="12"/>
+                                                    <color key="textColor" systemColor="systemGrayColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이번 배포를 위한 스프린트" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uXZ-KP-g1q">
+                                                    <rect key="frame" x="20" y="51" width="145" height="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                    <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="trailing" secondItem="pt5-pb-KY7" secondAttribute="trailing" constant="7" id="KzO-Up-Ugq"/>
+                                                <constraint firstItem="rSR-eL-HN5" firstAttribute="top" secondItem="Jjk-yG-MXh" secondAttribute="top" constant="11" id="Mce-PQ-Kcc"/>
+                                                <constraint firstItem="RwH-yC-dmP" firstAttribute="leading" secondItem="Jjk-yG-MXh" secondAttribute="leading" constant="20" id="OiR-Y9-iyj"/>
+                                                <constraint firstAttribute="bottom" secondItem="pt5-pb-KY7" secondAttribute="bottom" constant="13" id="QhQ-Xj-Nhy"/>
+                                                <constraint firstItem="uXZ-KP-g1q" firstAttribute="leading" secondItem="Jjk-yG-MXh" secondAttribute="leading" constant="20" id="XQH-Ta-FHT"/>
+                                                <constraint firstItem="2bC-bX-PVa" firstAttribute="trailing" secondItem="pt5-pb-KY7" secondAttribute="trailing" id="aOJ-NQ-Z37"/>
+                                                <constraint firstAttribute="bottom" secondItem="uXZ-KP-g1q" secondAttribute="bottom" constant="14" id="cSY-On-VkL"/>
+                                                <constraint firstItem="E8w-iB-xuz" firstAttribute="leading" secondItem="RwH-yC-dmP" secondAttribute="trailing" constant="15" id="eSe-38-yzu"/>
+                                                <constraint firstItem="E8w-iB-xuz" firstAttribute="centerY" secondItem="RwH-yC-dmP" secondAttribute="centerY" id="pZm-72-ifb"/>
+                                                <constraint firstItem="RwH-yC-dmP" firstAttribute="top" secondItem="Jjk-yG-MXh" secondAttribute="top" constant="13" id="utq-GN-2uj"/>
+                                                <constraint firstItem="pt5-pb-KY7" firstAttribute="top" secondItem="2bC-bX-PVa" secondAttribute="bottom" constant="1" id="w5I-4V-0fn"/>
+                                                <constraint firstAttribute="trailing" secondItem="rSR-eL-HN5" secondAttribute="trailing" constant="8" id="yqj-9m-F3o"/>
+                                            </constraints>
                                         </collectionViewCellContentView>
+                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <size key="customSize" width="413" height="82"/>
+                                        <connections>
+                                            <outlet property="closedIssueCount" destination="pt5-pb-KY7" id="8CC-Cm-fpF"/>
+                                            <outlet property="dueDate" destination="E8w-iB-xuz" id="SdA-Cn-Mnm"/>
+                                            <outlet property="info" destination="uXZ-KP-g1q" id="kb1-Te-4uC"/>
+                                            <outlet property="name" destination="RwH-yC-dmP" id="71g-df-Nd8"/>
+                                            <outlet property="openIssueCount" destination="2bC-bX-PVa" id="p3B-a1-kwP"/>
+                                            <outlet property="percentComplete" destination="rSR-eL-HN5" id="Ce3-98-rNW"/>
+                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                             </collectionView>
@@ -50,10 +131,13 @@
                     <navigationItem key="navigationItem" title="마일스톤" id="UVE-O6-1dW">
                         <barButtonItem key="rightBarButtonItem" image="plus" catalog="system" id="ffr-VY-6sb">
                             <connections>
-                                <segue destination="YwG-UJ-Jsn" kind="presentation" modalPresentationStyle="overFullScreen" id="6PW-jG-3aT"/>
+                                <segue destination="YwG-UJ-Jsn" kind="presentation" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="6PW-jG-3aT"/>
                             </connections>
                         </barButtonItem>
                     </navigationItem>
+                    <connections>
+                        <outlet property="collectionView" destination="w8F-kl-Cek" id="7y3-BZ-TV1"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fyr-TC-3si" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -64,20 +148,23 @@
             <objects>
                 <viewController id="YwG-UJ-Jsn" customClass="ManageMilestoneModalViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Aea-Pi-UXB">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mbw-83-YwP" customClass="ManageMilestoneModalView" customModule="IssueTracker" customModuleProvider="target">
-                                <rect key="frame" x="45.5" y="233" width="323.5" height="340"/>
+                                <rect key="frame" x="25.666666666666657" y="191" width="324" height="340"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vFw-ux-Z1T">
                                         <rect key="frame" x="14" y="10" width="30" height="34"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <state key="normal" image="xmark" catalog="system"/>
+                                        <connections>
+                                            <action selector="pressedClose:" destination="YwG-UJ-Jsn" eventType="touchUpInside" id="sw4-eu-WjP"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="PbB-f3-dcW">
-                                        <rect key="frame" x="0.0" y="51" width="323.5" height="1"/>
+                                        <rect key="frame" x="0.0" y="51" width="324" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="nZx-Sd-2wh"/>
@@ -87,17 +174,17 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이곳에 마일스톤 이름을 작성해주세요" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="1Ch-YB-FAy" userLabel="firstTextField">
-                                        <rect key="frame" x="78" y="92" width="205.5" height="18.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="78.000000000000085" y="92" width="206" height="18.666666666666671"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="yyyy-mm-dd (선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="bKf-57-VNC" userLabel="secondTextField">
-                                        <rect key="frame" x="77.5" y="165.5" width="206" height="18.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="77.333333333333343" y="165.66666666666663" width="206.66666666666669" height="18.333333333333343"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CnQ-YB-YHE">
-                                        <rect key="frame" x="238.5" y="288" width="70" height="42"/>
+                                        <rect key="frame" x="239" y="288" width="70" height="42"/>
                                         <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="42" id="noE-Fe-8WC"/>
@@ -112,15 +199,18 @@
                                                 <real key="value" value="10"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="pressedSave:" destination="YwG-UJ-Jsn" eventType="touchUpInside" id="Rhw-qF-euE"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="이름" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="omN-1U-Poc" userLabel="firstTextFieldLabel">
-                                        <rect key="frame" x="35" y="91" width="30" height="21"/>
+                                        <rect key="frame" x="35" y="90.666666666666686" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="완료날짜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sVW-2Z-cLe" userLabel="secondTextFieldLabel">
-                                        <rect key="frame" x="35" y="149" width="29.5" height="42"/>
+                                        <rect key="frame" x="35" y="148.66666666666669" width="29.333333333333329" height="42"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="42" id="PVd-ug-ey6"/>
                                             <constraint firstAttribute="width" constant="29.5" id="kKq-9S-qVm"/>
@@ -130,18 +220,18 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="c8f-bV-zKa" userLabel="thirdTextFieldLabel">
-                                        <rect key="frame" x="35" y="238" width="30" height="21"/>
+                                        <rect key="frame" x="35" y="237.66666666666669" width="30" height="21"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="이번 배포를 위한 스프린트 (선택)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Bec-z9-lLM" userLabel="thirdTextField">
-                                        <rect key="frame" x="78" y="239" width="205.5" height="18.5"/>
-                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <rect key="frame" x="78.000000000000085" y="239" width="206" height="18.666666666666686"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
                                         <textInputTraits key="textInputTraits"/>
                                     </textField>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Ih-ju-5c6">
-                                        <rect key="frame" x="20" y="124.5" width="283.5" height="1"/>
+                                        <rect key="frame" x="20" y="124.66666666666669" width="284" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="uui-mX-wsS"/>
@@ -151,7 +241,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IPz-Ns-JtT">
-                                        <rect key="frame" x="20" y="198" width="283.5" height="1"/>
+                                        <rect key="frame" x="20" y="198" width="284" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="a8p-gI-LIt"/>
@@ -161,7 +251,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Kn-ty-Eba">
-                                        <rect key="frame" x="20" y="271.5" width="283.5" height="1"/>
+                                        <rect key="frame" x="20" y="271.66666666666669" width="284" height="1"/>
                                         <color key="backgroundColor" systemColor="systemGray5Color"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="1" id="61v-qi-MU3"/>
@@ -176,23 +266,44 @@
                                         <state key="normal" title="초기화">
                                             <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </state>
+                                        <connections>
+                                            <action selector="pressedInitialize:" destination="YwG-UJ-Jsn" eventType="touchUpInside" id="tQi-ge-yo3"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rc7-xY-dNr">
-                                        <rect key="frame" x="30" y="133" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="29.999999999999996" y="133" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tFv-um-sId">
-                                        <rect key="frame" x="30" y="206.5" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="29.999999999999996" y="206.66666666666669" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B4z-IZ-nHz">
-                                        <rect key="frame" x="30" y="280" width="0.0" height="0.0"/>
+                                        <rect key="frame" x="29.999999999999996" y="280" width="0.0" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="11"/>
                                         <color key="textColor" red="0.99607843139999996" green="0.37647058820000001" blue="0.3294117647" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rie-lS-05D" userLabel="First Text Field Error Label">
+                                        <rect key="frame" x="19.999999999999996" y="133" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99681860209999995" green="0.37808820609999999" blue="0.32937520739999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EnI-3Z-Qkk" userLabel="Second Text Field Error Label">
+                                        <rect key="frame" x="19.999999999999996" y="206.66666666666669" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99681860209999995" green="0.37808820609999999" blue="0.32937520739999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="U0E-9z-3Lg" userLabel="Third Text Field Error Label">
+                                        <rect key="frame" x="19.999999999999996" y="280" width="0.0" height="0.0"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="11"/>
+                                        <color key="textColor" red="0.99681860209999995" green="0.37808820609999999" blue="0.32937520739999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
@@ -213,20 +324,25 @@
                                     <constraint firstItem="PbB-f3-dcW" firstAttribute="top" secondItem="mbw-83-YwP" secondAttribute="top" constant="51" id="FDj-Ig-d6d"/>
                                     <constraint firstAttribute="trailing" secondItem="CnQ-YB-YHE" secondAttribute="trailing" constant="15" id="GL4-ls-q2v"/>
                                     <constraint firstItem="6Ih-ju-5c6" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" id="Kcl-mo-scG"/>
+                                    <constraint firstItem="U0E-9z-3Lg" firstAttribute="top" secondItem="1Kn-ty-Eba" secondAttribute="bottom" constant="7.5" id="KeI-q2-KZr"/>
                                     <constraint firstItem="bKf-57-VNC" firstAttribute="bottom" secondItem="IPz-Ns-JtT" secondAttribute="bottom" constant="-15" id="PWP-V0-lKu"/>
                                     <constraint firstAttribute="trailing" secondItem="PbB-f3-dcW" secondAttribute="trailing" id="QXr-UK-Fcu"/>
                                     <constraint firstAttribute="trailing" secondItem="1Kn-ty-Eba" secondAttribute="trailing" constant="20" id="Rjy-vI-gde"/>
+                                    <constraint firstItem="U0E-9z-3Lg" firstAttribute="leading" secondItem="1Kn-ty-Eba" secondAttribute="leading" id="TCF-Pl-gst"/>
+                                    <constraint firstItem="EnI-3Z-Qkk" firstAttribute="leading" secondItem="IPz-Ns-JtT" secondAttribute="leading" id="UTc-by-BOz"/>
                                     <constraint firstItem="tFv-um-sId" firstAttribute="leading" secondItem="IPz-Ns-JtT" secondAttribute="leading" constant="10" id="Uiv-ua-3bF"/>
                                     <constraint firstItem="B4z-IZ-nHz" firstAttribute="top" secondItem="1Kn-ty-Eba" secondAttribute="bottom" constant="7.5" id="VNh-wu-5GH"/>
                                     <constraint firstItem="rc7-xY-dNr" firstAttribute="top" secondItem="6Ih-ju-5c6" secondAttribute="bottom" constant="7.5" id="VwE-kl-uNs"/>
                                     <constraint firstItem="rc7-xY-dNr" firstAttribute="leading" secondItem="6Ih-ju-5c6" secondAttribute="leading" constant="10" id="ZqR-zG-hz9"/>
                                     <constraint firstItem="1Kn-ty-Eba" firstAttribute="bottom" secondItem="Bec-z9-lLM" secondAttribute="bottom" constant="15" id="aCb-cN-3Lb"/>
+                                    <constraint firstItem="Rie-lS-05D" firstAttribute="leading" secondItem="6Ih-ju-5c6" secondAttribute="leading" id="bfp-27-7b3"/>
                                     <constraint firstItem="Bec-z9-lLM" firstAttribute="trailing" secondItem="1Kn-ty-Eba" secondAttribute="trailing" constant="-20" id="cWX-Xb-qdk"/>
                                     <constraint firstItem="PbB-f3-dcW" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" id="elP-L4-x7P"/>
                                     <constraint firstAttribute="trailing" secondItem="IPz-Ns-JtT" secondAttribute="trailing" constant="20" id="f1s-la-84D"/>
                                     <constraint firstItem="1Kn-ty-Eba" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" id="gfN-ZC-6Wu"/>
                                     <constraint firstItem="sVW-2Z-cLe" firstAttribute="centerY" secondItem="bKf-57-VNC" secondAttribute="centerY" constant="-5" id="krx-sf-g44"/>
                                     <constraint firstItem="bKf-57-VNC" firstAttribute="leading" secondItem="sVW-2Z-cLe" secondAttribute="trailing" constant="13" id="lEF-9L-Edd"/>
+                                    <constraint firstItem="EnI-3Z-Qkk" firstAttribute="top" secondItem="IPz-Ns-JtT" secondAttribute="bottom" constant="7.5" id="mbI-Sl-SeM"/>
                                     <constraint firstAttribute="bottom" secondItem="CnQ-YB-YHE" secondAttribute="bottom" constant="10" id="pIK-eY-ZPd"/>
                                     <constraint firstAttribute="height" constant="340" id="ptV-TO-Y8s"/>
                                     <constraint firstAttribute="trailing" secondItem="6Ih-ju-5c6" secondAttribute="trailing" constant="20" id="qwu-UF-ucl"/>
@@ -235,6 +351,7 @@
                                     <constraint firstItem="omN-1U-Poc" firstAttribute="centerY" secondItem="1Ch-YB-FAy" secondAttribute="centerY" id="spu-0n-lX4"/>
                                     <constraint firstItem="1Ch-YB-FAy" firstAttribute="leading" secondItem="omN-1U-Poc" secondAttribute="trailing" constant="13" id="wJA-bX-MaB"/>
                                     <constraint firstItem="8o8-yK-tCi" firstAttribute="leading" secondItem="mbw-83-YwP" secondAttribute="leading" constant="20" symbolic="YES" id="xgT-XM-QWO"/>
+                                    <constraint firstItem="Rie-lS-05D" firstAttribute="top" secondItem="6Ih-ju-5c6" secondAttribute="bottom" constant="7.5" id="xlP-KO-2C1"/>
                                     <constraint firstItem="omN-1U-Poc" firstAttribute="leading" secondItem="6Ih-ju-5c6" secondAttribute="leading" constant="15" id="yra-UU-rx8"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
@@ -251,9 +368,20 @@
                         <color key="backgroundColor" red="0.46570028297149824" green="0.46625122591040641" blue="0.5" alpha="0.5" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
                             <constraint firstItem="mbw-83-YwP" firstAttribute="centerX" secondItem="Aea-Pi-UXB" secondAttribute="centerX" id="Lee-9J-w44"/>
+                            <constraint firstItem="mbw-83-YwP" firstAttribute="leading" secondItem="7GD-1C-yxk" secondAttribute="leading" constant="20" id="Y1I-VA-FYF"/>
+                            <constraint firstItem="7GD-1C-yxk" firstAttribute="trailing" secondItem="mbw-83-YwP" secondAttribute="trailing" constant="20" id="jiP-eZ-vTk"/>
                             <constraint firstItem="mbw-83-YwP" firstAttribute="centerY" secondItem="Aea-Pi-UXB" secondAttribute="centerY" constant="-45" id="vzH-7h-8eU"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="firstTextField" destination="1Ch-YB-FAy" id="CoW-WV-Nai"/>
+                        <outlet property="firstTextFieldErrorLabel" destination="Rie-lS-05D" id="myK-Yq-8bU"/>
+                        <outlet property="secondTextField" destination="bKf-57-VNC" id="G0u-aC-lHs"/>
+                        <outlet property="secondTextFieldErrorLabel" destination="EnI-3Z-Qkk" id="6Gp-5w-j32"/>
+                        <outlet property="secondTextFieldLabel" destination="sVW-2Z-cLe" id="nYg-a1-SSA"/>
+                        <outlet property="thirdTextField" destination="Bec-z9-lLM" id="S9d-pe-TcW"/>
+                        <outlet property="thirdTextFieldErrorLabel" destination="U0E-9z-3Lg" id="ejv-ba-y3l"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Xkc-gV-fXF" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
@@ -267,7 +395,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="1mT-sv-gtf">
-                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="375" height="96"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -289,6 +417,12 @@
         </systemColor>
         <systemColor name="systemGray5Color">
             <color red="0.89803921568627454" green="0.89803921568627454" blue="0.91764705882352937" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGrayColor">
+            <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalView.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalView.swift
@@ -7,14 +7,14 @@
 
 import UIKit
 
+@IBDesignable
 class ManageMilestoneModalView: UIView {
 
-    /*
-    // Only override draw() if you perform custom drawing.
-    // An empty implementation adversely affects performance during animation.
-    override func draw(_ rect: CGRect) {
-        // Drawing code
+    @IBInspectable var cornerRadius: CGFloat = 0 {
+        
+        didSet {
+            layer.cornerRadius = cornerRadius
+            layer.masksToBounds = cornerRadius > 0
+        }
     }
-    */
-
 }

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalView.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalView.swift
@@ -1,0 +1,20 @@
+//
+//  ManageMilestoneModalView.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/05.
+//
+
+import UIKit
+
+class ManageMilestoneModalView: UIView {
+
+    /*
+    // Only override draw() if you perform custom drawing.
+    // An empty implementation adversely affects performance during animation.
+    override func draw(_ rect: CGRect) {
+        // Drawing code
+    }
+    */
+
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ManageMilestoneModalViewController.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/05.
+//
+
+import UIKit
+
+class ManageMilestoneModalViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
@@ -8,22 +8,145 @@
 import UIKit
 
 class ManageMilestoneModalViewController: UIViewController {
-
+    
+    @IBOutlet var secondTextFieldLabel: UILabel!
+    
+    @IBOutlet var firstTextField: UITextField!
+    @IBOutlet var secondTextField: UITextField!
+    @IBOutlet var thirdTextField: UITextField!
+    
+    @IBOutlet var firstTextFieldErrorLabel: UILabel!
+    @IBOutlet var secondTextFieldErrorLabel: UILabel!
+    @IBOutlet var thirdTextFieldErrorLabel: UILabel!
+    
     override func viewDidLoad() {
+        
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
+        
+        initializeAllFields()
+        configureTextField()
     }
     
+}
 
-    /*
-    // MARK: - Navigation
+// MARK: - 텍스트필드 설정
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+extension ManageMilestoneModalViewController {
+    
+    private func configureTextField() {
+        
+        let allTextFields: [UITextField] = [firstTextField, secondTextField, thirdTextField]
+        
+        allTextFields.forEach { textfield in
+            textfield.addTarget(self, action: #selector(checkTextField(textfield:)), for: .editingChanged)
+        }
     }
-    */
+    
+    @objc private func checkTextField (textfield: UITextField) {
+        
+        switch textfield {
+        case firstTextField:
+            do {
+                try firstTextField.validatedText(validationType: .requiredField(field: "이름"))
+                try firstTextField.validatedText(validationType: .milestoneName)
+                firstTextFieldErrorLabel.text = ""
+            } catch (let error) {
+                firstTextFieldErrorLabel.text = (error as! ValidationError).message
+            }
+        case secondTextField:
+            do {
+                try secondTextField.validatedText(validationType: .milestoneDueDate)
+                secondTextFieldErrorLabel.text = ""
+                secondTextFieldLabel.textColor = UIColor.black
+            } catch (let error) {
+                secondTextFieldLabel.textColor = UIColor.systemRed
+                secondTextFieldErrorLabel.text = (error as! ValidationError).message
+            }
+        case thirdTextField:
+            do {
+                try thirdTextField.validatedText(validationType: .milestoneInfo)
+                thirdTextFieldErrorLabel.text = ""
+            } catch (let error) {
+                thirdTextFieldErrorLabel.text = (error as! ValidationError).message
+            }
+        default: break
+        }
+    }
+}
 
+// MARK: - IBActions
+
+extension ManageMilestoneModalViewController {
+    
+    @IBAction func pressedClose(_ sender: UIButton) {
+        
+        dismiss(animated: true, completion: nil)
+    }
+    @IBAction func pressedInitialize(_ sender: UIButton) {
+        
+        initializeAllFields()
+    }
+    
+    @IBAction func pressedSave(_ sender: UIButton) {
+        
+        do {
+            try firstTextField.validatedText(validationType: .requiredField(field: "이름"))
+            
+            let _ = try firstTextField.validatedText(validationType: .milestoneName)
+            let _ = try secondTextField.validatedText(validationType: .milestoneDueDate)
+            let _ = try thirdTextField.validatedText(validationType: .milestoneInfo)
+        } catch (let error) {
+            alertValidationErrorOnSave(error: error)
+            return
+        }
+        
+        alertProceedSave()
+        // TODO: alertProceedSave 안에서 OK 시 위의 3가지 값(milestoneName, milestoneDueDate, milestoneInfo)을 서버로 전송하기
+    }
+}
+
+// MARK: - 경고창
+
+extension ManageMilestoneModalViewController {
+    
+    private func alertProceedSave() {
+        
+        let saveAlert = UIAlertController(title: "알림", message: "마일스톤을 저장하시겠습니까?", preferredStyle: UIAlertController.Style.alert)
+        
+        saveAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action: UIAlertAction!) in
+            // TODO: 값 저장하기
+            self.dismiss(animated: true, completion: nil)
+        }))
+        
+        saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        present(saveAlert, animated: true, completion: nil)
+    }
+    
+    private func alertValidationErrorOnSave(error: Error) {
+        
+        let validationErrorAlert = UIAlertController(title: "잠깐! 🤗", message: (error as! ValidationError).message, preferredStyle: .alert)
+        
+        validationErrorAlert.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
+        
+        self.present(validationErrorAlert, animated: true, completion: nil)
+    }
+}
+
+// MARK: -
+
+extension ManageMilestoneModalViewController {
+    
+    private func initializeAllFields() {
+        
+        firstTextField.text = ""
+        secondTextField.text = ""
+        thirdTextField.text = ""
+        
+        firstTextFieldErrorLabel.text = ""
+        secondTextFieldErrorLabel.text = ""
+        thirdTextFieldErrorLabel.text = ""
+        
+        secondTextFieldLabel.textColor = UIColor.black
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ManageMilestoneViewController.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/05.
+//
+
+import UIKit
+
+class ManageMilestoneViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -7,23 +7,65 @@
 
 import UIKit
 
-class ManageMilestoneViewController: UIViewController {
+final class ManageMilestoneViewController: UIViewController {
 
+    @IBOutlet var collectionView: UICollectionView!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        // Do any additional setup after loading the view.
+        collectionView.dataSource = self
+        
+        configureLayout()
     }
     
+}
 
-    /*
-    // MARK: - Navigation
+// MARK: - Layout
 
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
+extension ManageMilestoneViewController {
+    
+    private func configureLayout() {
+        
+        let collectionViewFlowLayout = UICollectionViewFlowLayout()
+        collectionViewFlowLayout.itemSize = CGSize(width: view.bounds.size.width, height: 77)
+        collectionViewFlowLayout.minimumLineSpacing = 1
+        collectionViewFlowLayout.sectionInset = UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
+        collectionView.collectionViewLayout = collectionViewFlowLayout
     }
-    */
+}
 
+// MARK: - DataSource
+
+extension ManageMilestoneViewController: UICollectionViewDataSource {
+    
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        
+        return 1
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        
+        return 2
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MilestoneCell.reuseIdentifier, for: indexPath)
+        // TODO: 각 cell을 터치했을 때 편집화면으로 이동해야한다.
+        return cell
+    }
+}
+
+// MARK: - MilestoneCell
+
+final class MilestoneCell: UICollectionViewCell {
+    
+    static let reuseIdentifier = String(describing: MilestoneCell.self)
+    @IBOutlet var name: UIButton!
+    @IBOutlet var dueDate: UILabel!
+    @IBOutlet var percentComplete: UILabel!
+    @IBOutlet var info: UILabel!
+    @IBOutlet var openIssueCount: UILabel!
+    @IBOutlet var closedIssueCount: UILabel!
 }

--- a/iOS/IssueTracker/IssueTracker/Extension/String+.swift
+++ b/iOS/IssueTracker/IssueTracker/Extension/String+.swift
@@ -1,0 +1,16 @@
+//
+//  String+.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/05.
+//
+
+import Foundation
+
+extension String {
+    
+    func matchesRegexPattern(_ pattern: String) throws -> Bool {
+        
+        return try NSRegularExpression(pattern: pattern, options: .caseInsensitive).firstMatch(in: self, options: [], range: _NSRange(location: 0, length: self.count)) == nil
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Extension/UITextField+.swift
+++ b/iOS/IssueTracker/IssueTracker/Extension/UITextField+.swift
@@ -1,0 +1,17 @@
+//
+//  UITextField+.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/05.
+//
+
+import UIKit
+
+extension UITextField {
+    @discardableResult
+    func validatedText(validationType: ValidatorType) throws -> String {
+        
+        let validator = ValidatorFactory.validatorFor(type: validationType)
+        return try validator.validate(self.text!)
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Model/InputValidator.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/InputValidator.swift
@@ -14,7 +14,7 @@ protocol ValidatorConvertible {
 
 enum ValidatorType {
     
-    case labelName, labelInfo, labelColor, requiredField(field: String)
+    case labelName, labelInfo, labelColor, milestoneName, milestoneDueDate, milestoneInfo, requiredField(field: String)
 }
 
 enum ValidatorFactory {
@@ -28,6 +28,12 @@ enum ValidatorFactory {
             return LabelInfoValidator()
         case .labelColor:
             return LabelColorValidator()
+        case .milestoneName:
+            return MilestoneNameValidator()
+        case .milestoneDueDate:
+            return MilestoneDueDateValidator()
+        case .milestoneInfo:
+            return MilestoneInfoValidator()
         case .requiredField(field: let fieldName):
             return RequiredFieldValidator(fieldName)
         }
@@ -70,7 +76,7 @@ private struct LabelColorValidator: ValidatorConvertible {
         
         let matchError = ValidationError("올바른 16진수 색상 값이 아닙니다. 예) #93DAFF")
         let lengthError = ValidationError("# 특수문자를 포함하여 총 7자여야합니다. 예) #93DAFF")
-        guard value.count <= 7 else { throw lengthError }
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines).count <= 7 else { throw lengthError }
         
         do {
             if try value.trimmingCharacters(in: .whitespacesAndNewlines).matchesRegexPattern("#[0-9a-f]{6}") {
@@ -79,6 +85,42 @@ private struct LabelColorValidator: ValidatorConvertible {
         } catch {
             throw matchError
         }
+        return value
+    }
+}
+
+private struct MilestoneNameValidator: ValidatorConvertible {
+    
+    func validate(_ value: String) throws -> String {
+        
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines).count < 20
+        else { throw ValidationError("마일스톤 이름은 20자 미만이어야 합니다.") }
+        return value
+    }
+}
+
+private struct MilestoneDueDateValidator: ValidatorConvertible {
+    
+    func validate(_ value: String) throws -> String {
+        
+        let matchError = ValidationError("올바른 날짜 형식이 아닙니다. \n 예) 2020-11-05")
+        do {
+            if try value.trimmingCharacters(in: .whitespacesAndNewlines).matchesRegexPattern("[0-9]{4}-[0-9]{2}-[0-9]{2}") {
+                throw matchError
+            }
+        } catch {
+            throw matchError
+        }
+        return value
+    }
+}
+
+private struct MilestoneInfoValidator: ValidatorConvertible {
+    
+    func validate(_ value: String) throws -> String {
+        
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines).count < 30
+        else { throw ValidationError("마일스톤 설명은 30자 미만이어야 합니다.") }
         return value
     }
 }
@@ -97,13 +139,5 @@ private struct RequiredFieldValidator: ValidatorConvertible {
             throw ValidationError("\"\(fieldName)\" 은 필수항목입니다.")
         }
         return value
-    }
-}
-
-extension String {
-    
-    func matchesRegexPattern(_ pattern: String) throws -> Bool {
-        
-        return try NSRegularExpression(pattern: pattern, options: .caseInsensitive).firstMatch(in: self, options: [], range: _NSRange(location: 0, length: self.count)) == nil
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Model/InputValidator.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/InputValidator.swift
@@ -103,6 +103,8 @@ private struct MilestoneDueDateValidator: ValidatorConvertible {
     
     func validate(_ value: String) throws -> String {
         
+        guard value.trimmingCharacters(in: .whitespacesAndNewlines).count > 0 else { return "" }
+        
         let matchError = ValidationError("올바른 날짜 형식이 아닙니다. \n 예) 2020-11-05")
         do {
             if try value.trimmingCharacters(in: .whitespacesAndNewlines).matchesRegexPattern("[0-9]{4}-[0-9]{2}-[0-9]{2}") {

--- a/iOS/IssueTracker/IssueTracker/SupportingFile/Storyboard/Base.lproj/Main.storyboard
+++ b/iOS/IssueTracker/IssueTracker/SupportingFile/Storyboard/Base.lproj/Main.storyboard
@@ -113,6 +113,7 @@
                     <connections>
                         <segue destination="EcO-C0-4Qd" kind="relationship" relationship="viewControllers" id="XQG-Lq-EGG"/>
                         <segue destination="mxQ-DE-Jdl" kind="relationship" relationship="viewControllers" id="7g9-qE-Vzc"/>
+                        <segue destination="LE8-ZI-OTC" kind="relationship" relationship="viewControllers" id="NCC-ij-Zht"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="vyJ-z4-918" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -127,7 +128,17 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5gv-61-Roa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1679" y="322"/>
+            <point key="canvasLocation" x="2047" y="114"/>
+        </scene>
+        <!--ManageMilestoneInitialController-->
+        <scene sceneID="aP2-y4-kGh">
+            <objects>
+                <viewControllerPlaceholder storyboardName="ManageMilestone" referencedIdentifier="ManageMilestoneInitialController" id="LE8-ZI-OTC" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="Item" id="zZ6-uA-Xt0"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="jE0-VE-I5x" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1762" y="260"/>
         </scene>
         <!--IssueListInitialController-->
         <scene sceneID="pgs-GO-chh">
@@ -137,7 +148,7 @@
                 </viewControllerPlaceholder>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="agi-qx-EEb" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1625" y="-82"/>
+            <point key="canvasLocation" x="1724" y="-83"/>
         </scene>
     </scenes>
     <resources>


### PR DESCRIPTION
# 제목

## 해당 이슈 📎

https://github.com/boostcamp-2020/IssueTracker-7/issues/43

## 변경 사항 🛠

- [x] 마일스톤 탭으로 이동하여 마일스톤 목록을 볼 수 있다.
- [ ] 서버로부터 마일스톤 목록을 받아온다.
- [x] 마일스톤 생성 버튼을 통해 마일스톤 생성 화면으로 이동할 수 있다.
- [x] 마일스톤 생성화면에서 제목, 완료날짜, 설명을 추가할 수 있다.
- [x] 각 input field는 validator를 통해 검증을 거친다
- [x] "완료날짜"와 "설명" 항목은 선택사항으로 안넣어도 저장을 할 수 있어야한다.
- [x] 초기화 버튼을 누르면 입력한 값을 모두 초기화한다.
- [x] 저장 버튼을 누르면 입력한 값으로 저장한다.
- [x] 저장 전에 확인차 알림창을 띄운다.
- [ ] 저장시 서버로 값을 전송하여 저장한다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️


![Screen Shot 2020-11-05 at 6 43 59 PM](https://user-images.githubusercontent.com/46217844/98225985-bc535500-1f98-11eb-9348-2d2e97875e08.png)
![Screen Shot 2020-11-05 at 6 44 15 PM](https://user-images.githubusercontent.com/46217844/98225988-bcebeb80-1f98-11eb-92ce-f34d566e3d42.png)
![Screen Shot 2020-11-05 at 6 47 46 PM](https://user-images.githubusercontent.com/46217844/98225990-be1d1880-1f98-11eb-9422-f8680ee365a1.png)



![Screen Shot 2020-11-05 at 6 42 57 PM](https://user-images.githubusercontent.com/46217844/98225982-ba899180-1f98-11eb-8b24-498d8b6e49e8.png)

