### PR TITLE
레이블 생성 API 구현

### DIFF
--- a/backend/controllers/label.js
+++ b/backend/controllers/label.js
@@ -1,8 +1,16 @@
-const { Label } = require('../models');
+const labelService = require('../services/label');
 
-exports.get = (req, res) => {
-    Label.findAll({
-        attributes: ['id', 'name', 'description', 'color']
-    }).then(labels => res.status(200).json(labels))
-    .catch(err => res.status(401).send('유효하지 않은 요청입니다.'));
+exports.get = async (req, res) => {
+    const labels = await labelService.getAll();
+    if (labels) res.json(labels);
+    res.status(401).json('유효하지 않은 요청입니다.');
+};
+
+exports.add = async (req, res) => {
+    const newLabel = req.body;
+    const label = await labelService.findByName(newLabel);
+    
+    if (label) res.json(false);
+    const result = await labelService.create(newLabel);
+    res.json(result);
 };

--- a/backend/controllers/label.js
+++ b/backend/controllers/label.js
@@ -8,9 +8,6 @@ exports.get = async (req, res) => {
 
 exports.add = async (req, res) => {
     const newLabel = req.body;
-    const label = await labelService.findByName(newLabel);
-    
-    if (label) res.json(false);
     const result = await labelService.create(newLabel);
     res.json(result);
 };

--- a/backend/routes/api/label.js
+++ b/backend/routes/api/label.js
@@ -3,5 +3,6 @@ const router = express.Router();
 const labelController = require('../../controllers/label');
 
 router.get('/', labelController.get);
+router.post('/', labelController.add);
 
 module.exports = router;

--- a/backend/services/label.js
+++ b/backend/services/label.js
@@ -1,0 +1,31 @@
+const { Label } = require('../models');
+
+exports.getAll = async () => {
+    let result;
+    try {
+        result = await Label.findAll({ attributes: ['id', 'name', 'description', 'color'] });
+    } catch (err) {
+        return false;
+    }
+    return result;
+
+}
+exports.findByName = async (label) => {
+    let result;
+    try {
+        result = await Label.findOne({ where: { name: label.name } });
+    } catch (err) {
+        return false;
+    }
+    return result;
+}
+
+exports.create = async (label) => {
+    let result;
+    try {
+        result = await Label.create(label);
+    } catch (err) {
+        return false;
+    }
+    return result;
+}

--- a/backend/services/label.js
+++ b/backend/services/label.js
@@ -21,11 +21,14 @@ exports.findByName = async (label) => {
 }
 
 exports.create = async (label) => {
-    let result;
+    const { name, description, color } = newLabel;
     try {
-        result = await Label.create(label);
+        const result = await Label.findOrCreate({
+            where: { name: name },
+            defaults: { description: description, color: color }
+        });
+        return result[1];
     } catch (err) {
         return false;
     }
-    return result;
 }

--- a/backend/services/label.js
+++ b/backend/services/label.js
@@ -20,15 +20,16 @@ exports.findByName = async (label) => {
     return result;
 }
 
-exports.create = async (label) => {
+exports.create = async (newLabel) => {
     const { name, description, color } = newLabel;
     try {
         const result = await Label.findOrCreate({
             where: { name: name },
             defaults: { description: description, color: color }
         });
-        return result[1];
+        if (result[1]) return { status: 200, data: result[0] };
+        else return { status: 401, data: { message: '이미 레이블이 존재합니다.' } };
     } catch (err) {
-        return false;
+        return { status: 401, data: { message: '유효하지 않은 입력입니다.'}};
     }
 }


### PR DESCRIPTION
# 레이블 생성 API 구현

## 해당 이슈 📎

#124 

## 변경 사항 🛠

구현내용 요약

- 컨트롤러의 로직을 서비스로 분리했다.
- 레이블 생성을 위한 API를 구현했다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

