### PR TITLE
이슈를 Close / Delete 할 수 있다.

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -34,6 +34,8 @@
 		333FE2992551214A000C0F0B /* RegParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333FE2982551214A000C0F0B /* RegParser.swift */; };
 		333FE2A52551513F000C0F0B /* DetailIssueList.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 333FE2A42551513F000C0F0B /* DetailIssueList.storyboard */; };
 		333FE2AA25515167000C0F0B /* DetailIssueListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333FE2A925515167000C0F0B /* DetailIssueListController.swift */; };
+		33493B49255662B100BB1E11 /* IssueCellContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33493B48255662B100BB1E11 /* IssueCellContentView.swift */; };
+		33493B4E2556632800BB1E11 /* IssueCellContentView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33493B4D2556632800BB1E11 /* IssueCellContentView.xib */; };
 		3358A56C254D1C95008CEFA3 /* GithubAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358A56B254D1C95008CEFA3 /* GithubAPIManager.swift */; };
 		3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358A573254D1D5F008CEFA3 /* BackEndAPI.swift */; };
 		3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3358A57B254ED757008CEFA3 /* StoryboardID.swift */; };
@@ -132,6 +134,8 @@
 		333FE2982551214A000C0F0B /* RegParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegParser.swift; sourceTree = "<group>"; };
 		333FE2A42551513F000C0F0B /* DetailIssueList.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DetailIssueList.storyboard; sourceTree = "<group>"; };
 		333FE2A925515167000C0F0B /* DetailIssueListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueListController.swift; sourceTree = "<group>"; };
+		33493B48255662B100BB1E11 /* IssueCellContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueCellContentView.swift; sourceTree = "<group>"; };
+		33493B4D2556632800BB1E11 /* IssueCellContentView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IssueCellContentView.xib; sourceTree = "<group>"; };
 		3358A56B254D1C95008CEFA3 /* GithubAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GithubAPIManager.swift; sourceTree = "<group>"; };
 		3358A573254D1D5F008CEFA3 /* BackEndAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackEndAPI.swift; sourceTree = "<group>"; };
 		3358A57B254ED757008CEFA3 /* StoryboardID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoryboardID.swift; sourceTree = "<group>"; };
@@ -460,6 +464,8 @@
 			children = (
 				339F611D2553FF7B00FDB2A9 /* DetailIssueCell.swift */,
 				3393E0D125530B33003DCDA4 /* IssueCell.swift */,
+				33493B48255662B100BB1E11 /* IssueCellContentView.swift */,
+				33493B4D2556632800BB1E11 /* IssueCellContentView.xib */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -658,6 +664,7 @@
 				33375C432547E71000E8A8E8 /* Assets.xcassets in Resources */,
 				33375C412547E70E00E8A8E8 /* Main.storyboard in Resources */,
 				33151F2925499E04006B94A9 /* NanumSquareOTF_acEB.otf in Resources */,
+				33493B4E2556632800BB1E11 /* IssueCellContentView.xib in Resources */,
 				333FE2A52551513F000C0F0B /* DetailIssueList.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -704,6 +711,7 @@
 				718C389D2553E72E002E4903 /* ManageMilestoneModalViewController.swift in Sources */,
 				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				3393E0AC2552698C003DCDA4 /* UIView+.swift in Sources */,
+				33493B49255662B100BB1E11 /* IssueCellContentView.swift in Sources */,
 				3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */,
 				339F611E2553FF7B00FDB2A9 /* DetailIssueCell.swift in Sources */,
 				3393E0BD2552AACC003DCDA4 /* IssueData.swift in Sources */,
@@ -731,7 +739,6 @@
 				339892B22549876B00D9FB63 /* UserInfo.swift in Sources */,
 				7130A6CC2552A2A700EE2141 /* UIColor+.swift in Sources */,
 				718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */,
-				3322CFA52553B8810022ABA6 /* AppleSignInButton.swift in Sources */,
 				3322CFAA2553B8900022ABA6 /* AppleSignInButton.swift in Sources */,
 				339892A125497CB400D9FB63 /* UserDefault.swift in Sources */,
 				3393E09525523D29003DCDA4 /* CardView.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueList.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="collection view cell content view" minToolsVersion="11.0"/>
@@ -50,76 +50,9 @@
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="ONO-gj-CGL">
                                             <rect key="frame" x="0.0" y="0.0" width="413" height="134"/>
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                            <subviews>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 전체 목록을 볼 수 있어야 한다. 2줄까지 보입니다. 뒷줄은 잘리게 될 것 입니다 쩜쩜쩜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rRY-D3-c3q">
-                                                    <rect key="frame" x="15" y="46" width="300" height="41"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="2tS-Pr-XBv"/>
-                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="41" id="bFF-6b-ZHC"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="btQ-GT-NEf">
-                                                    <rect key="frame" x="332" y="16" width="73" height="20"/>
-                                                    <accessibility key="accessibilityConfiguration">
-                                                        <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
-                                                    </accessibility>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="73" id="MHN-bM-8qV"/>
-                                                        <constraint firstAttribute="height" constant="20" id="xmr-Vw-HGT"/>
-                                                    </constraints>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                    <state key="normal" title="스프린트 2">
-                                                        <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                    </state>
-                                                    <userDefinedRuntimeAttributes>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                                            <real key="value" value="1"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                            <real key="value" value="7"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                                            <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                        </userDefinedRuntimeAttribute>
-                                                    </userDefinedRuntimeAttributes>
-                                                </button>
-                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 목록 보기 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Ac-H0-ytB">
-                                                    <rect key="frame" x="15" y="16" width="162.5" height="23"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                                    <nil key="textColor"/>
-                                                    <nil key="highlightedColor"/>
-                                                </label>
-                                                <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="h10-3i-8ED">
-                                                    <rect key="frame" x="15" y="100" width="17" height="24"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="25" id="NjM-fL-NHY"/>
-                                                    </constraints>
-                                                </stackView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="7Ac-H0-ytB" firstAttribute="leading" secondItem="ONO-gj-CGL" secondAttribute="leading" constant="15" id="7IB-Gn-odC"/>
-                                                <constraint firstItem="btQ-GT-NEf" firstAttribute="top" secondItem="7Ac-H0-ytB" secondAttribute="top" id="QIL-rS-jk0"/>
-                                                <constraint firstItem="rRY-D3-c3q" firstAttribute="leading" secondItem="7Ac-H0-ytB" secondAttribute="leading" id="RBb-5Y-unO"/>
-                                                <constraint firstItem="h10-3i-8ED" firstAttribute="leading" secondItem="rRY-D3-c3q" secondAttribute="leading" id="T2R-6Q-6Kd"/>
-                                                <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="h10-3i-8ED" secondAttribute="trailing" constant="380" id="Zyw-rE-b2d"/>
-                                                <constraint firstItem="rRY-D3-c3q" firstAttribute="top" secondItem="7Ac-H0-ytB" secondAttribute="bottom" constant="7" id="bQE-SC-JJ0"/>
-                                                <constraint firstItem="7Ac-H0-ytB" firstAttribute="top" secondItem="ONO-gj-CGL" secondAttribute="top" constant="16" id="jPF-lS-saF"/>
-                                                <constraint firstAttribute="trailing" secondItem="btQ-GT-NEf" secondAttribute="trailing" constant="8" id="tDk-Fk-9Ub"/>
-                                                <constraint firstAttribute="bottom" secondItem="h10-3i-8ED" secondAttribute="bottom" constant="10" id="uF4-L0-uiG"/>
-                                                <constraint firstItem="h10-3i-8ED" firstAttribute="top" secondItem="rRY-D3-c3q" secondAttribute="bottom" constant="13" id="wAD-ON-5CP"/>
-                                            </constraints>
                                         </collectionViewCellContentView>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <size key="customSize" width="413" height="134"/>
-                                        <connections>
-                                            <outlet property="content" destination="rRY-D3-c3q" id="pvf-d0-ex9"/>
-                                            <outlet property="labelStackView" destination="h10-3i-8ED" id="gr5-Jd-vPf"/>
-                                            <outlet property="milestone" destination="btQ-GT-NEf" id="Zyo-lZ-Qgp"/>
-                                            <outlet property="title" destination="7Ac-H0-ytB" id="3U9-Py-N0W"/>
-                                        </connections>
                                     </collectionViewCell>
                                 </cells>
                                 <collectionReusableView key="sectionHeaderView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="searchBarHeader" id="0cA-bn-GO8" customClass="CustomSearchBar" customModule="IssueTracker" customModuleProvider="target">
@@ -201,9 +134,6 @@
     <resources>
         <image name="1.circle.fill" catalog="system" width="128" height="121"/>
         <image name="plus.circle.fill" catalog="system" width="128" height="121"/>
-        <systemColor name="labelColor">
-            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -89,6 +89,7 @@ extension IssueListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: IssueCell.reuseIdentifier, for: indexPath) as! IssueCell
+        cell.delegate = self
         cell.configure(issueData: issueDataList[indexPath.row])
         
         return cell
@@ -121,4 +122,14 @@ extension IssueListViewController: UISearchBarDelegate {
     }
 }
 
+extension IssueListViewController: IssueCellDelegate {
+    func IssueListDidInteracted(cell: IssueCell) {
+        guard let visibleCells = collectionView.visibleCells as? [IssueCell] else { return }
+        visibleCells.forEach { visibleCell in
+            if  cell != visibleCell {
+                cell.resetOffset()
+            }
+        }
+    }
+}
 

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -123,12 +123,22 @@ extension IssueListViewController: UISearchBarDelegate {
 }
 
 extension IssueListViewController: IssueCellDelegate {
-    func IssueListDidInteracted(cell: IssueCell) {
+    func issueListDidInteracted(cell: IssueCell) {
         guard let visibleCells = collectionView.visibleCells as? [IssueCell] else { return }
         visibleCells.forEach { visibleCell in
             if  cell != visibleCell {
-                cell.resetOffset()
+                visibleCell.resetOffset()
             }
+        }
+    }
+}
+
+extension IssueListViewController: UIScrollViewDelegate {
+    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        guard let visibleCells = collectionView.visibleCells as? [IssueCell] else { return }
+        visibleCells.forEach { visibleCell in
+            visibleCell.resetOffset()
         }
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -97,13 +97,7 @@ extension IssueListViewController: UICollectionViewDataSource {
 }
 
 extension IssueListViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        let storyboard = UIStoryboard(name: "DetailIssueList", bundle: nil)
-        let viewController = storyboard.instantiateViewController(identifier: "DetailIssueListController")
-        
-        navigationController?.pushViewController(viewController, animated: true)
-
-    }
+   
     func collectionView(_ collectionView: UICollectionView, viewForSupplementaryElementOfKind kind: String, at indexPath: IndexPath) -> UICollectionReusableView {
         
         let headerView = collectionView.dequeueReusableSupplementaryView(
@@ -112,17 +106,18 @@ extension IssueListViewController: UICollectionViewDelegate {
                 for: indexPath)
         
         return headerView
-
     }
 }
 
 extension IssueListViewController: UISearchBarDelegate {
+    
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         print("입력")
     }
 }
 
 extension IssueListViewController: IssueCellDelegate {
+    
     func issueListDidInteracted(cell: IssueCell) {
         guard let visibleCells = collectionView.visibleCells as? [IssueCell] else { return }
         visibleCells.forEach { visibleCell in
@@ -130,6 +125,19 @@ extension IssueListViewController: IssueCellDelegate {
                 visibleCell.resetOffset()
             }
         }
+    }
+    
+    func issueListDidTapped(cell: IssueCell) {
+        
+        guard let visibleCells = collectionView.visibleCells as? [IssueCell] else { return }
+        for visibleCell in visibleCells {
+            if visibleCell.isSwiped() { return }
+        }
+        
+        let storyboard = UIStoryboard(name: "DetailIssueList", bundle: nil)
+        let viewController = storyboard.instantiateViewController(identifier: "DetailIssueListController")
+        
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/Extension/UIView+.swift
+++ b/iOS/IssueTracker/IssueTracker/Extension/UIView+.swift
@@ -15,4 +15,14 @@ extension UIView {
         self.layer.shadowRadius = radius
         self.layer.shadowOpacity = opacity
     }
+    
+    func pinEdgesToSuperView() {
+        guard let superView = superview else { return }
+        translatesAutoresizingMaskIntoConstraints = false
+        topAnchor.constraint(equalTo: superView.topAnchor).isActive = true
+        leftAnchor.constraint(equalTo: superView.leftAnchor).isActive = true
+        bottomAnchor.constraint(equalTo: superView.bottomAnchor).isActive = true
+        rightAnchor.constraint(equalTo: superView.rightAnchor).isActive = true
+    }
 }
+

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -46,13 +46,16 @@ final class IssueCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
+        scrollView.delegate = self
         setUpView()
         setUpSwipable()
+        setUpTapGesture()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
+        scrollView.delegate = self
         setUpView()
         setUpSwipable()
         setUpTapGesture()
@@ -115,6 +118,15 @@ final class IssueCell: UICollectionViewCell {
 
     func configure(issueData: IssueData) {
         visibleView.configure(issueData: issueData)
+    }
+}
+
+
+// MARK: - Extension
+
+extension IssueCell: UIScrollViewDelegate {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollView.bounces = scrollView.contentOffset.x > 0
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol IssueCellDelegate: AnyObject {
-    func IssueListDidInteracted(cell: IssueCell)
+    func issueListDidInteracted(cell: IssueCell)
 }
 
 final class IssueCell: UICollectionViewCell {
@@ -86,7 +86,7 @@ final class IssueCell: UICollectionViewCell {
     }
     
     @objc private func contentTapped() {
-        delegate?.IssueListDidInteracted(cell: self)
+        delegate?.issueListDidInteracted(cell: self)
     }
     
     @objc private func closeIssue() {
@@ -170,7 +170,9 @@ extension IssueCell: UIScrollViewDelegate {
         }
     }
     
-    
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        delegate?.issueListDidInteracted(cell: self)
+    }
 }
 
 

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -13,6 +13,25 @@ final class IssueCell: UICollectionViewCell {
     
     static let reuseIdentifier = String(describing: IssueCell.self)
     
+    // For swipe
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.isPagingEnabled = true
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.showsHorizontalScrollIndicator = false
+        return scrollView
+    }()
+    
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.frame = bounds
+        stackView.axis = .horizontal
+        stackView.distribution = .fill
+        return stackView
+    }()
+    
+    private var visibleView: IssueCellContentView!
+    
     
     // MARK: - Initializer
     
@@ -20,12 +39,14 @@ final class IssueCell: UICollectionViewCell {
         super.init(frame: frame)
         
         setUpView()
+        setUpSwipable()
     }
     
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
         setUpView()
+        setUpSwipable()
     }
 
     // MARK: - Method
@@ -33,6 +54,41 @@ final class IssueCell: UICollectionViewCell {
     override func prepareForReuse() {
         visibleView.initLabels()
     }
+    
+    private func setUpSwipable() {
+        addSubview(scrollView)
+        scrollView.addSubview(stackView)
+
+        scrollView.pinEdgesToSuperView()
+        stackView.pinEdgesToSuperView()
+        
+        visibleView = IssueCellContentView()
+        
+        let hiddenView = UIView()
+        hiddenView.backgroundColor = UIColor.blue
+        
+        let hiddenView2 = UIView()
+        hiddenView2.backgroundColor = UIColor.systemRed
+        
+        stackView.addArrangedSubview(visibleView)
+        stackView.addArrangedSubview(hiddenView)
+        stackView.addArrangedSubview(hiddenView2)
+        
+        
+        visibleView.translatesAutoresizingMaskIntoConstraints = false
+        hiddenView.translatesAutoresizingMaskIntoConstraints = false
+        hiddenView2.translatesAutoresizingMaskIntoConstraints = false
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        
+        
+        NSLayoutConstraint.activate([
+            stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 1.4),
+            stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
+            
+            visibleView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            hiddenView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2),
+            hiddenView2.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2)
+        ])
     }
     
     private func setUpView() {

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -169,7 +169,7 @@ final class IssueCell: UICollectionViewCell {
 
 extension IssueCell: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        if scrollView.contentOffset.x < 0 {
+        if scrollView.contentOffset.x <= 0 {
             scrollView.contentOffset.x = 0
             scrollView.bounces = false
         } else {

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -7,11 +7,16 @@
 
 import UIKit
 
+protocol IssueCellDelegate: AnyObject {
+    func IssueListDidInteracted(cell: IssueCell)
+}
+
 final class IssueCell: UICollectionViewCell {
     
     // MARK: - Property
     
     static let reuseIdentifier = String(describing: IssueCell.self)
+    weak var delegate: IssueCellDelegate?
     
     // For swipe
     private lazy var scrollView: UIScrollView = {
@@ -42,6 +47,7 @@ final class IssueCell: UICollectionViewCell {
         return view
     }()
     
+    
     // MARK: - Initializer
     
     override init(frame: CGRect) {
@@ -69,6 +75,9 @@ final class IssueCell: UICollectionViewCell {
     }
     
     private func setUpTapGesture() {
+        let visibleRecognizer = UITapGestureRecognizer(target: self, action: #selector(contentTapped))
+        visibleView.addGestureRecognizer(visibleRecognizer)
+        
         let closeRecognizer = UITapGestureRecognizer(target: self, action: #selector(closeIssue))
         closeView.addGestureRecognizer(closeRecognizer)
         
@@ -76,6 +85,9 @@ final class IssueCell: UICollectionViewCell {
         deleteView.addGestureRecognizer(deleteRecognizer)
     }
     
+    @objc private func contentTapped() {
+        delegate?.IssueListDidInteracted(cell: self)
+    }
     
     @objc private func closeIssue() {
         print("close")
@@ -137,6 +149,12 @@ final class IssueCell: UICollectionViewCell {
     func configure(issueData: IssueData) {
         visibleView.configure(issueData: issueData)
     }
+    
+    func resetOffset() {
+        UIViewPropertyAnimator(duration: 0.2, curve: .easeInOut) {
+            self.scrollView.contentOffset.x = 0
+        }.startAnimation()
+    }
 }
 
 
@@ -145,7 +163,13 @@ final class IssueCell: UICollectionViewCell {
 extension IssueCell: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         scrollView.bounces = scrollView.contentOffset.x > 0
+        
+        delegate?.IssueListDidInteracted(cell: self)
     }
+    
+    
 }
+
+
 
 

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -162,9 +162,12 @@ final class IssueCell: UICollectionViewCell {
 
 extension IssueCell: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollView.bounces = scrollView.contentOffset.x > 0
-        
-        delegate?.IssueListDidInteracted(cell: self)
+        if scrollView.contentOffset.x < 0 {
+            scrollView.contentOffset.x = 0
+            scrollView.bounces = false
+        } else {
+            scrollView.bounces = true
+        }
     }
     
     

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -9,6 +9,7 @@ import UIKit
 
 protocol IssueCellDelegate: AnyObject {
     func issueListDidInteracted(cell: IssueCell)
+    func issueListDidTapped(cell: IssueCell)
 }
 
 final class IssueCell: UICollectionViewCell {
@@ -86,6 +87,7 @@ final class IssueCell: UICollectionViewCell {
     }
     
     @objc private func contentTapped() {
+        delegate?.issueListDidTapped(cell: self)
         delegate?.issueListDidInteracted(cell: self)
     }
     
@@ -151,10 +153,15 @@ final class IssueCell: UICollectionViewCell {
     }
     
     func resetOffset() {
-        UIViewPropertyAnimator(duration: 0.2, curve: .easeInOut) {
+        UIViewPropertyAnimator(duration: 0.3, curve: .easeInOut) {
             self.scrollView.contentOffset.x = 0
         }.startAnimation()
     }
+    
+    func isSwiped() -> Bool {
+        scrollView.contentOffset.x != 0
+    }
+    
 }
 
 

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -19,6 +19,7 @@ final class IssueCell: UICollectionViewCell {
         scrollView.isPagingEnabled = true
         scrollView.showsVerticalScrollIndicator = false
         scrollView.showsHorizontalScrollIndicator = false
+        scrollView.backgroundColor = .systemRed
         return scrollView
     }()
     
@@ -109,6 +110,23 @@ final class IssueCell: UICollectionViewCell {
             closeView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2),
             deleteView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2)
         ])
+        
+        addImage(view: closeView, imageName: "xmark.rectangle")
+        addImage(view: deleteView, imageName: "trash")
+    }
+    
+    func addImage(view: UIView, imageName: String) {
+        let image = UIImage(systemName: imageName)
+        let imageView = UIImageView(image: image)
+        imageView.tintColor = .white
+        
+        view.addSubview(imageView)
+        
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        imageView.centerYAnchor.constraint(equalTo: view.centerYAnchor).isActive = true
+        imageView.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        imageView.heightAnchor.constraint(equalToConstant: 30).isActive = true
     }
     
     private func setUpView() {

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -24,14 +24,22 @@ final class IssueCell: UICollectionViewCell {
     
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
-        stackView.frame = bounds
         stackView.axis = .horizontal
         stackView.distribution = .fill
         return stackView
     }()
     
-    private var visibleView: IssueCellContentView!
-    
+    private let visibleView = IssueCellContentView()
+    private var closeView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.systemGreen
+        return view
+    }()
+    private var deleteView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor.systemRed
+        return view
+    }()
     
     // MARK: - Initializer
     
@@ -47,6 +55,7 @@ final class IssueCell: UICollectionViewCell {
         
         setUpView()
         setUpSwipable()
+        setUpTapGesture()
     }
 
     // MARK: - Method
@@ -55,39 +64,47 @@ final class IssueCell: UICollectionViewCell {
         visibleView.initLabels()
     }
     
+    private func setUpTapGesture() {
+        let closeRecognizer = UITapGestureRecognizer(target: self, action: #selector(closeIssue))
+        closeView.addGestureRecognizer(closeRecognizer)
+        
+        let deleteRecognizer = UITapGestureRecognizer(target: self, action: #selector(deleteIssue))
+        deleteView.addGestureRecognizer(deleteRecognizer)
+    }
+    
+    
+    @objc private func closeIssue() {
+        print("close")
+    }
+    
+    
+    @objc private func deleteIssue() {
+        print("delete")
+    }
+    
     private func setUpSwipable() {
         addSubview(scrollView)
         scrollView.addSubview(stackView)
 
         scrollView.pinEdgesToSuperView()
         stackView.pinEdgesToSuperView()
-        
-        visibleView = IssueCellContentView()
-        
-        let hiddenView = UIView()
-        hiddenView.backgroundColor = UIColor.blue
-        
-        let hiddenView2 = UIView()
-        hiddenView2.backgroundColor = UIColor.systemRed
-        
+                
         stackView.addArrangedSubview(visibleView)
-        stackView.addArrangedSubview(hiddenView)
-        stackView.addArrangedSubview(hiddenView2)
-        
+        stackView.addArrangedSubview(closeView)
+        stackView.addArrangedSubview(deleteView)
         
         visibleView.translatesAutoresizingMaskIntoConstraints = false
-        hiddenView.translatesAutoresizingMaskIntoConstraints = false
-        hiddenView2.translatesAutoresizingMaskIntoConstraints = false
+        closeView.translatesAutoresizingMaskIntoConstraints = false
+        deleteView.translatesAutoresizingMaskIntoConstraints = false
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        
         
         NSLayoutConstraint.activate([
             stackView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 1.4),
             stackView.heightAnchor.constraint(equalTo: scrollView.heightAnchor),
             
             visibleView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
-            hiddenView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2),
-            hiddenView2.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2)
+            closeView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2),
+            deleteView.widthAnchor.constraint(equalTo: scrollView.widthAnchor, multiplier: 0.2)
         ])
     }
     

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCell.swift
@@ -12,10 +12,6 @@ final class IssueCell: UICollectionViewCell {
     // MARK: - Property
     
     static let reuseIdentifier = String(describing: IssueCell.self)
-    @IBOutlet var title: UILabel!
-    @IBOutlet var content: UILabel!
-    @IBOutlet var milestone: UIButton!
-    @IBOutlet weak var labelStackView: UIStackView!
     
     
     // MARK: - Initializer
@@ -35,45 +31,17 @@ final class IssueCell: UICollectionViewCell {
     // MARK: - Method
     
     override func prepareForReuse() {
-        labelStackView.arrangedSubviews.forEach {
-            $0.removeFromSuperview()
-        }
+        visibleView.initLabels()
+    }
     }
     
-    func setUpView() {
+    private func setUpView() {
         layer.cornerRadius = 10
         layer.masksToBounds = true
     }
-    
-    func hexStringToUIColor (hex: String) -> UIColor {
-        var rgbValue: UInt64 = 0
-        let droppedString = hex.dropFirst()
 
-        Scanner(string: String(droppedString)).scanHexInt64(&rgbValue)
-
-        return UIColor(
-            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
-            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
-            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
-            alpha: CGFloat(1.0)
-        )
-    }
-    
     func configure(issueData: IssueData) {
-        title.text = issueData.title
-        // cell.content.text = // TODO: API 쪽에서 아직 구현이 안되서 추후 수정
-        milestone.setTitle(issueData.milestone.title, for: .normal)
-        
-        issueData.labels?.forEach {
-            let btn = UIButton()
-            btn.setTitle(" \($0.name) ", for: .normal)
-            btn.backgroundColor = hexStringToUIColor(hex: $0.color)
-            btn.setTitleColor(UIColor.black, for: .normal)
-            btn.titleLabel?.font = .systemFont(ofSize: 15)
-            btn.cornerRadius = 5
-            
-            labelStackView.addArrangedSubview(btn)
-        }
+        visibleView.configure(issueData: issueData)
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
@@ -31,12 +31,12 @@ class IssueCellContentView: UIView {
         }
     }
     
-    func hexStringToUIColor (hex: String) -> UIColor {
+    private func hexStringToUIColor (hex: String) -> UIColor {
         var rgbValue: UInt64 = 0
         let droppedString = hex.dropFirst()
 
         Scanner(string: String(droppedString)).scanHexInt64(&rgbValue)
-
+        
         return UIColor(
             red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
             green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
@@ -63,7 +63,7 @@ class IssueCellContentView: UIView {
         }
     }
     
-    func loadViewFromNib() -> UIView? {
+    private func loadViewFromNib() -> UIView? {
         let bundle = Bundle(for: type(of: self))
         let nib = UINib(nibName: String(describing: IssueCellContentView.self), bundle: bundle)
         return nib.instantiate(
@@ -71,7 +71,7 @@ class IssueCellContentView: UIView {
                     options: nil).first as? UIView
     }
     
-    func xibSetup() {
+    private func xibSetup() {
         guard let view = loadViewFromNib() else { return }
         view.frame = bounds
         addSubview(view)

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
@@ -1,0 +1,80 @@
+//
+//  IssueCellContentView.swift
+//  IssueTracker
+//
+//  Created by a1111 on 2020/11/07.
+//
+
+import UIKit
+
+class IssueCellContentView: UIView {
+    
+    @IBOutlet var title: UILabel!
+    @IBOutlet var content: UILabel!
+    @IBOutlet var milestone: UIButton!
+    @IBOutlet weak var labelStackView: UIStackView!
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        xibSetup()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        
+    }
+    
+    func initLabels() {
+        labelStackView.arrangedSubviews.forEach {
+            $0.removeFromSuperview()
+        }
+    }
+    
+    func hexStringToUIColor (hex: String) -> UIColor {
+        var rgbValue: UInt64 = 0
+        let droppedString = hex.dropFirst()
+
+        Scanner(string: String(droppedString)).scanHexInt64(&rgbValue)
+
+        return UIColor(
+            red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0,
+            alpha: CGFloat(1.0)
+        )
+    }
+    
+    func configure(issueData: IssueData) {
+        
+        title.text = issueData.title
+        // cell.content.text = // TODO: API 쪽에서 아직 구현이 안되서 추후 수정
+        milestone.setTitle(issueData.milestone.title, for: .normal)
+        
+        issueData.labels?.forEach {
+            let btn = UIButton()
+            btn.setTitle(" \($0.name) ", for: .normal)
+            btn.backgroundColor = hexStringToUIColor(hex: $0.color)
+            btn.setTitleColor(UIColor.black, for: .normal)
+            btn.titleLabel?.font = .systemFont(ofSize: 15)
+            btn.cornerRadius = 5
+            
+            labelStackView.addArrangedSubview(btn)
+        }
+    }
+    
+    func loadViewFromNib() -> UIView? {
+        let bundle = Bundle(for: type(of: self))
+        let nib = UINib(nibName: String(describing: IssueCellContentView.self), bundle: bundle)
+        return nib.instantiate(
+                    withOwner: self,
+                    options: nil).first as? UIView
+    }
+    
+    func xibSetup() {
+        guard let view = loadViewFromNib() else { return }
+        view.frame = bounds
+        addSubview(view)
+    }
+    
+}

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.swift
@@ -9,10 +9,15 @@ import UIKit
 
 class IssueCellContentView: UIView {
     
+    // MARK: - Property
+    
     @IBOutlet var title: UILabel!
     @IBOutlet var content: UILabel!
     @IBOutlet var milestone: UIButton!
     @IBOutlet weak var labelStackView: UIStackView!
+    
+    
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -23,7 +28,11 @@ class IssueCellContentView: UIView {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
         
+        xibSetup()
     }
+    
+    
+    // MARK: - Method
     
     func initLabels() {
         labelStackView.arrangedSubviews.forEach {

--- a/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.xib
+++ b/iOS/IssueTracker/IssueTracker/View/Cell/IssueCellContentView.xib
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="IssueCellContentView" customModule="IssueTracker" customModuleProvider="target">
+            <connections>
+                <outlet property="content" destination="bSr-YV-p98" id="e3J-oa-urc"/>
+                <outlet property="labelStackView" destination="en7-wK-gpR" id="KM7-aV-NqG"/>
+                <outlet property="milestone" destination="vbc-DR-tdp" id="a7p-hr-foX"/>
+                <outlet property="title" destination="JAU-gS-nWy" id="Sod-u5-Fml"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="429" height="137"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 전체 목록을 볼 수 있어야 한다. 2줄까지 보입니다. 뒷줄은 잘리게 될 것 입니다 쩜쩜쩜" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSr-YV-p98">
+                    <rect key="frame" x="13" y="45" width="300" height="41"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="4aw-LW-gFP"/>
+                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="41" id="CD8-sZ-woT"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vbc-DR-tdp">
+                    <rect key="frame" x="343" y="13" width="73" height="20"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" button="YES" notEnabled="YES"/>
+                    </accessibility>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="20" id="dDd-ng-LPM"/>
+                        <constraint firstAttribute="width" constant="73" id="l7C-pM-Q6c"/>
+                    </constraints>
+                    <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                    <state key="normal" title="스프린트 2">
+                        <color key="titleColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    </state>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                            <real key="value" value="1"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                            <real key="value" value="7"/>
+                        </userDefinedRuntimeAttribute>
+                        <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                            <color key="value" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </userDefinedRuntimeAttribute>
+                    </userDefinedRuntimeAttributes>
+                </button>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블 목록 보기 구현" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JAU-gS-nWy">
+                    <rect key="frame" x="13" y="13" width="162.5" height="25"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="en7-wK-gpR">
+                    <rect key="frame" x="13" y="99" width="0.0" height="25"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="386-qo-dft">
+                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="25"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstAttribute="width" id="ftw-cl-f4B"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="height" relation="lessThanOrEqual" constant="25" id="2uH-fG-M5F"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="bSr-YV-p98" firstAttribute="top" secondItem="JAU-gS-nWy" secondAttribute="bottom" constant="7" id="1FS-S7-Lfe"/>
+                <constraint firstItem="vbc-DR-tdp" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="13" id="BJu-7c-anu"/>
+                <constraint firstItem="JAU-gS-nWy" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="13" id="KN2-yS-nt1"/>
+                <constraint firstItem="JAU-gS-nWy" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="13" id="MVS-wJ-cxa"/>
+                <constraint firstAttribute="bottom" secondItem="en7-wK-gpR" secondAttribute="bottom" constant="13" id="ela-jL-Y3d"/>
+                <constraint firstItem="vbc-DR-tdp" firstAttribute="top" secondItem="JAU-gS-nWy" secondAttribute="top" id="hbh-VE-j4p"/>
+                <constraint firstItem="bSr-YV-p98" firstAttribute="leading" secondItem="JAU-gS-nWy" secondAttribute="leading" id="hzT-SW-Uvp"/>
+                <constraint firstItem="en7-wK-gpR" firstAttribute="top" secondItem="bSr-YV-p98" secondAttribute="bottom" constant="13" id="nwH-i9-iPp"/>
+                <constraint firstAttribute="trailing" secondItem="vbc-DR-tdp" secondAttribute="trailing" constant="13" id="oQo-9A-cot"/>
+                <constraint firstItem="en7-wK-gpR" firstAttribute="leading" secondItem="bSr-YV-p98" secondAttribute="leading" id="z4A-q4-nuZ"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="151.44927536231884" y="180.46875"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>


### PR DESCRIPTION
# 이슈를 Close / Delete 할 수 있다.

## 해당 이슈 📎
#38 - 이슈를 close 할 수 있다
#37 - 이슈를 delete 할 수 있다

## 변경 사항 🛠

- [x] Swipe 기능 구현
- [x] 애플 기본 메모 어플리케이션과 유사하게 동작해야 한다.
     - [x] close/delete 클릭 시 해당 cell 은 swipe 이전 상태로 돌아와야 한다.
     - [x] cell 이 swipe 되있는 경우 다른 cell 을 swipe 하면 기존 swipe 된 cell 은 swipe 이전 상태로 돌아와야 한다.
     - [x] 이미 다른 cell 이 swipe 되있는 경우 cell 을 탭 했을 때 swipe 이전 상태로 돌려놓는다. 만약 어떤 cell 도 swipe 상태가 아닌 경우에만 해당 cell 에 대한 상세화면으로 넘어간다.
     - [x] 컬렉션 뷰를 스크롤 하면 swipe 된 cell 을 swipe 이전 상태로 복구시킨다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

![image](https://user-images.githubusercontent.com/20080283/98437233-fdc43b80-2123-11eb-943f-aa273c1189b5.png)

![ezgif com-gif-maker (13)](https://user-images.githubusercontent.com/20080283/98437384-036e5100-2125-11eb-9736-ee784dc71e95.gif)

애플 메모 어플을 직접 써보니,
1. 컬렉션뷰를 스크롤 하면 현재 swipe 된 cell 의 swipe 를 해제
2. 다른 cell 을 swipe 하면 현재 swipe 된 cell 의 swipe 를 해제
3. cell 을 탭했을 때 swipe 된 cell 이 있는 경우 해당 cell 의 swipe 를 해제하더라구요.
그리고 한 번 더 탭 해야 상세화면으로 넘어가길래 이를 그대로 구현했습니다 ~ 

[참고링크](https://www.amerhukic.com/swipeable-collection-view-cell)