### PR TITLE
sequelize의 Op 객체를 가져오도록 수정

### DIFF
--- a/backend/services/issue.js
+++ b/backend/services/issue.js
@@ -1,5 +1,5 @@
 const { Issue, Label, User, Comment, label_has_issue, Milestone, sequelize } = require('../models');
-const Op = sequelize.Op;
+const Op = require('sequelize').Op;
 const optionParser = (queryString) => queryString.match(/(\w+|@)([@/-\w가-힇]+)|(".*?")+(?=\:?)/gi);
 const optionStringToObject = (queryString) => {
   const queryArray = optionParser(queryString);


### PR DESCRIPTION
# sequelize의 Op 객체를 가져오도록 수정

## 해당 이슈 📎

#174

## 변경 사항 🛠

구현내용 요약

- sequelize 라이브러리에서 Op 객체를 가져오도록 수정

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

