### PR TITLE
이슈 목록 편집 방식 변경 및 개선

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -155,7 +155,6 @@ extension IssueListViewController {
 
                 DispatchQueue.main.async {
                     self.collectionView.reloadSections(IndexSet(integer: 0))
-//                    self.collectionView.reloadData()
                 }
             case .failure(let error):
                 print(error)

--- a/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/IssueList/IssueListViewController.swift
@@ -155,6 +155,7 @@ extension IssueListViewController {
 
                 DispatchQueue.main.async {
                     self.collectionView.reloadSections(IndexSet(integer: 0))
+//                    self.collectionView.reloadData()
                 }
             case .failure(let error):
                 print(error)
@@ -213,11 +214,11 @@ extension IssueListViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if isEditing {
             setNavigationTitle()
-            print("selected item")
-        } 
+        }
     }
 }
 
+// MARK: 컬렉션뷰 DelegateFlowLayout
 extension IssueListViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         
@@ -260,6 +261,14 @@ extension IssueListViewController: IssueCellDelegate {
         navigationController?.pushViewController(viewController, animated: true)
     }
     
+    private func batchUpdateCells(of indexPaths: [IndexPath]) {
+        self.collectionView.performBatchUpdates {
+            UIViewPropertyAnimator(duration: 1, curve: .easeInOut) {
+                self.collectionView.reloadItems(at: indexPaths)
+            }.startAnimation()
+        }
+    }
+    
     func issueStatusChanged(cell: IssueCell) {
         guard let indexPath = collectionView.indexPath(for: cell) else { return }
         let issueInfo = issueInfoList[indexPath.item]
@@ -267,7 +276,10 @@ extension IssueListViewController: IssueCellDelegate {
         api.requestStatusChange(issueInfo: issueInfo, status: status) { result in
             switch result {
             case .success:
-                self.configureInitialData()
+                self.issueInfoList[indexPath.item].status = status.rawValue
+                DispatchQueue.main.async {
+                    self.batchUpdateCells(of: [indexPath])
+                }
             case .failure(let error):
                 print(error)
             }
@@ -312,34 +324,47 @@ extension IssueListViewController {
         }
     }
     
-    @IBAction func pressedOpenSelectedItems(_ sender: Any) {
-        guard let selectedItems = collectionView.indexPathsForSelectedItems else { return }
+    private func changeInfoStatus(of indexPaths: [IndexPath], to status: Status) {
+        indexPaths.forEach { indexPath in
+            self.issueInfoList[indexPath.item].status = status.rawValue
+        }
+    }
+    
+    private func changeStatus(selectedItems: [IndexPath], to status: Status) {
+        let group = DispatchGroup()
+        var indexPaths: [IndexPath] = []
         
-        selectedItems.forEach {
-            api.requestStatusChange(issueInfo: issueInfoList[$0.item], status: .open) { result in
+        selectedItems.forEach { indexPath in
+            group.enter()
+            api.requestStatusChange(issueInfo: issueInfoList[indexPath.item], status: status) { result in
                 switch result {
                 case .success:
-                    self.configureInitialData()
+                    indexPaths.append(indexPath)
                 case .failure(let error):
                     print(error)
                 }
+                group.leave()
             }
         }
+        
+        group.notify(queue: .main) {
+            self.changeInfoStatus(of: indexPaths, to: status)
+           
+            self.batchUpdateCells(of: indexPaths)
+            self.selectAllActive = false
+        }
+    }
+    
+    @IBAction func pressedOpenSelectedItems(_ sender: Any) {
+        guard let selectedItems = collectionView.indexPathsForSelectedItems else { return }
+        
+        changeStatus(selectedItems: selectedItems, to: .open)
     }
     
     @IBAction func pressedCloseSelectedItems(_ sender: UIBarButtonItem) {
         guard let selectedItems = collectionView.indexPathsForSelectedItems else { return }
         
-        selectedItems.forEach {
-            api.requestStatusChange(issueInfo: issueInfoList[$0.item], status: .closed) { result in
-                switch result {
-                case .success:
-                    self.configureInitialData()
-                case .failure(let error):
-                    print(error)
-                }
-            }
-        }
+        changeStatus(selectedItems: selectedItems, to: .closed)
     }
     
     @objc private func pressedSelectAllButton() {

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
@@ -11,7 +11,7 @@ import Foundation
 struct IssueInfo: Codable {
     let id: Int
     let title: String
-    let status: String
+    var status: String
     let createdAt: String?
     let updatedAt: String?
     let deletedAt: String?


### PR DESCRIPTION
# 이슈 목록 편집 방식 변경 및 개선

## 해당 이슈 📎
#226 - 이슈 목록 편집 방식 변경 및 개선
이슈 제목 및 링크

## 변경 사항 🛠

구현내용 요약

- cell 을 모두 갱신하는 것이 아니라 변경한 데이터에 대해서만 갱신
- 일괄 오픈/클로즈 후 전체선택 해제되지 않는 버그 수정

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

~~~
    @IBAction func pressedOpenSelectedItems(_ sender: Any) {
        guard let selectedItems = collectionView.indexPathsForSelectedItems else { return }
        
        changeStatus(selectedItems: selectedItems, to: .open)
    }
    
    @IBAction func pressedCloseSelectedItems(_ sender: UIBarButtonItem) {
        guard let selectedItems = collectionView.indexPathsForSelectedItems else { return }
        
        changeStatus(selectedItems: selectedItems, to: .closed)
    }
~~~

각각 선택 이슈 열기 / 선택 이슈 닫기 버튼 시 동작하는 action 입니다.
</br>

~~~
    private func changeStatus(selectedItems: [IndexPath], to status: Status) {
        let group = DispatchGroup()
        var indexPaths: [IndexPath] = []
        
        selectedItems.forEach { indexPath in
            group.enter()
            api.requestStatusChange(issueInfo: issueInfoList[indexPath.item], status: status) { result in
                switch result {
                case .success:
                    indexPaths.append(indexPath) // 서버로부터 성공 응답을 받은 indexPath 를 저장
                case .failure(let error):
                    print(error)
                }
                group.leave()
            }
        }
        
        group.notify(queue: .main) { // 모든 API 통신이 끝날 때까지 대기합니다.
            self.changeInfoStatus(of: indexPaths, to: status)
           
            self.batchUpdateCells(of: indexPaths)
            self.selectAllActive = false
        }
    }
~~~

기존에는 서버로부터 데이터를 다 받아와서 갱신하는 방식이었는데,
너무 비효율적이라고 생각되서 로컬의 데이터를 갱신하고 반영하는 방식으로 변경했습니다.

서버로부터 성공 응답을 받은 indexPath 를 저장합니다.
DispatchGroup 을 통해 모든 API 통신이 끝날 때까지, 변경에 성공한 모든 indexPath를 저장합니다.

이 때 forEach 가 5번 도는 경우,
group.enter() -> group.enter() -> group.enter() -> group.enter() -> group.enter()
-> group.leave() -> group.leave() -> group.leave() -> group.leave() -> group.leave() 식으로 동작합니다.

서버로부터 모든 응답을 받으면(== group.leave() 가 group.enter() 의 개수만큼 동작하면) group.notify 가 동작합니다.


</br>

~~~
    private func changeInfoStatus(of indexPaths: [IndexPath], to status: Status) {
        indexPaths.forEach { indexPath in
            self.issueInfoList[indexPath.item].status = status.rawValue
        }
    }
~~~

1. changeInfoStatus(): 해당 indexPath들에 있는 데이터(issueInfoList[indexPath.item]) 들 의 상태(open/close)를 변경합니다.
</br>

~~~
    private func batchUpdateCells(of indexPaths: [IndexPath]) {
        self.collectionView.performBatchUpdates {
            UIViewPropertyAnimator(duration: 1, curve: .easeInOut) {
                self.collectionView.reloadItems(at: indexPaths)
            }.startAnimation()
        }
    }
~~~

2. batchUpdateCells(): 방금 모델의 데이터를 변경했으니, 이제는 방금 갱신한 데이터들을 화면에 띄우기 위해 cell 들을 갱신합니다. performBatchUpdates 를 이용하여 cell 들의 상태를 한꺼번에 갱신합니다.



    
