### PR TITLE
레이블 및 마일스톤 목록화면 버그 수정

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
@@ -180,6 +180,9 @@
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="설명" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6MT-0W-J90" userLabel="secondTextFieldLabel">
                                         <rect key="frame" x="35" y="164.5" width="30" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="30" id="duG-O0-uYt"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneModalViewController.swift
@@ -190,7 +190,7 @@ extension ManageMilestoneModalViewController {
         
         firstTextField.text = (milestoneInfo?.title != nil) ? milestoneInfo?.title : ""
         secondTextField.text = (milestoneInfo?.dueDate != nil) ? milestoneInfo?.dueDate : ""
-        thirdTextField.text = ""
+        thirdTextField.text = (milestoneInfo?.description != nil) ? milestoneInfo?.description : ""
         
         firstTextFieldErrorLabel.text = ""
         secondTextFieldErrorLabel.text = ""

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -140,7 +140,7 @@ final class MilestoneCell: UICollectionViewCell {
         
         name.setTitle(milestoneData.title, for: .normal)
         dueDate.text = milestoneData.dueDate
-        
+        milestoneDescription.text = milestoneData.description
         addShadow()
     }
     

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
@@ -14,10 +14,10 @@ struct MilestonesInfo: Codable {
 // MARK: - Milestone
 struct MilestoneInfo: Codable {
     let id: Int
-    let title, dueDate: String
+    let title, dueDate, description: String
 
     enum CodingKeys: String, CodingKey {
-        case id, title
+        case id, title, description
         case dueDate = "due_date"
     }
 }


### PR DESCRIPTION
# 레이블 및 마일스톤 목록화면 버그 수정

## 해당 이슈 📎

https://github.com/boostcamp-2020/IssueTracker-7/issues/230

## 변경 사항 🛠

- 레이블 모달창에서 설명이 너무 긴 경우 "설명" 레이블이 ... 으로 변환되는 것을 수정
- 마일스톤 목록화면에서 각 cell의 마일스톤 설명이 서버로부터 온 데이터가 반영이 안되는 점을 수정

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

