### PR TITLE
마일스톤 진행률을 표시한다

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageLabel/ManageLabel.storyboard
@@ -10,7 +10,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--레이블-->
+        <!--레이블 🏷-->
         <scene sceneID="1sX-ax-4a8">
             <objects>
                 <viewController id="Euh-Aj-MVR" customClass="ManageLabelViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
@@ -97,7 +97,7 @@
                             <constraint firstItem="MJS-qW-swq" firstAttribute="leading" secondItem="Zaa-0z-Ikc" secondAttribute="leading" id="lIN-xT-9zr"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="레이블" largeTitleDisplayMode="always" id="yhZ-Oa-Fvc">
+                    <navigationItem key="navigationItem" title="레이블 🏷" largeTitleDisplayMode="always" id="yhZ-Oa-Fvc">
                         <barButtonItem key="rightBarButtonItem" image="plus" catalog="system" id="spd-id-sj9">
                             <connections>
                                 <segue destination="jRf-jR-yWq" kind="presentation" identifier="ModalViewControllerSegue" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="INO-NC-xKl"/>
@@ -379,7 +379,7 @@
                     <toolbarItems/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" largeTitles="YES" id="jEl-XB-ON9">
-                        <rect key="frame" x="0.0" y="44" width="414" height="96"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="104.5"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestone.storyboard
@@ -9,7 +9,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--마일스톤-->
+        <!--마일스톤🗿-->
         <scene sceneID="8jE-eh-h63">
             <objects>
                 <viewController id="BEF-ob-tcE" customClass="ManageMilestoneViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
@@ -128,7 +128,7 @@
                             <constraint firstItem="w8F-kl-Cek" firstAttribute="top" secondItem="Fdc-il-ex1" secondAttribute="top" id="mT1-QG-mga"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" title="마일스톤" id="UVE-O6-1dW">
+                    <navigationItem key="navigationItem" title="마일스톤🗿" id="UVE-O6-1dW">
                         <barButtonItem key="rightBarButtonItem" image="plus" catalog="system" id="ffr-VY-6sb">
                             <connections>
                                 <segue destination="YwG-UJ-Jsn" kind="presentation" identifier="ManageMilestoneModalViewControllerSegue" modalPresentationStyle="overFullScreen" modalTransitionStyle="crossDissolve" id="6PW-jG-3aT"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -137,10 +137,22 @@ final class MilestoneCell: UICollectionViewCell {
     @IBOutlet var closedIssueCount: UILabel!
         
     fileprivate func configure(milestoneData: MilestoneInfo) {
+        let numberOfOpenIssues = milestoneData.issues.filter { $0.status == "open" }.count
+        let numberOfClosedIssues = milestoneData.issues.filter { $0.status == "closed" }.count
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        numberFormatter.locale = Locale(identifier: "en_US")
+        
+        let fractionOfCompleteIssues = (Double(numberOfOpenIssues) / Double(numberOfOpenIssues + numberOfClosedIssues))
+        let percentCompleteString = numberFormatter.string(from: NSNumber(value: fractionOfCompleteIssues))
+        
         
         name.setTitle(milestoneData.title, for: .normal)
         dueDate.text = milestoneData.dueDate
-        
+        milestoneDescription.text = milestoneData.description
+        openIssueCount.text = "\(numberOfOpenIssues) open"
+        closedIssueCount.text = "\(numberOfClosedIssues) closed"
+        percentComplete.text =  fractionOfCompleteIssues.isNaN ? "0%" : percentCompleteString
         addShadow()
     }
     

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
@@ -14,10 +14,15 @@ struct MilestonesInfo: Codable {
 // MARK: - Milestone
 struct MilestoneInfo: Codable {
     let id: Int
-    let title, dueDate: String
-
+    let title, dueDate, description: String
+    let issues: [IssuesInMilestone]
     enum CodingKeys: String, CodingKey {
-        case id, title
+        case id, title, description, issues
         case dueDate = "due_date"
     }
+}
+
+struct IssuesInMilestone: Codable {
+    let id: Int
+    let title, status: String
 }


### PR DESCRIPTION
# 마일스톤 진행률을 표시한다

## 해당 이슈 📎

https://github.com/boostcamp-2020/IssueTracker-7/issues/229

## 변경 사항 🛠

구현내용 요약

- 마일스톤 목록화면에서 오픈 이슈와 닫힌 이슈의 비율을 계산하여 마일스톤 진행률을 표시한다. 
- 마일스톤에 등록된 이슈가 없을 경우와 닫힌 이슈가 없는 경우에는 0% 로 표기한다.
## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

