### PR TITLE
이슈 생성화면을 열 수 있다. part2

### DIFF
--- a/iOS/IssueTracker/IssueTracker/Controller/RegisterIssue/RegisterIssue.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/RegisterIssue/RegisterIssue.storyboard
@@ -98,6 +98,15 @@
                                     <constraint firstItem="hLS-Fq-LbG" firstAttribute="leading" secondItem="B5n-0n-u7W" secondAttribute="leading" id="tQB-S1-6uj"/>
                                 </constraints>
                             </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n4y-da-19G">
+                                <rect key="frame" x="20" y="99" width="250" height="0.0"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="250" id="nXj-7V-zil"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <color key="textColor" systemColor="systemPinkColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ObJ-i8-8CK"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -109,10 +118,12 @@
                             <constraint firstItem="idB-yn-buE" firstAttribute="width" secondItem="qP8-o9-R2v" secondAttribute="width" id="Bgl-6o-DXL"/>
                             <constraint firstItem="ajT-fE-68f" firstAttribute="top" secondItem="idB-yn-buE" secondAttribute="bottom" constant="20" id="DfL-yi-TPc"/>
                             <constraint firstItem="ObJ-i8-8CK" firstAttribute="bottom" secondItem="B5n-0n-u7W" secondAttribute="bottom" id="ECA-lf-Qxd"/>
+                            <constraint firstItem="n4y-da-19G" firstAttribute="top" secondItem="idB-yn-buE" secondAttribute="bottom" constant="3" id="Iye-m6-jHk"/>
                             <constraint firstItem="idB-yn-buE" firstAttribute="leading" secondItem="qP8-o9-R2v" secondAttribute="leading" id="WJf-TI-SS9"/>
                             <constraint firstItem="B5n-0n-u7W" firstAttribute="centerX" secondItem="qXF-79-Vib" secondAttribute="centerX" id="XEf-pq-oZh"/>
                             <constraint firstItem="B5n-0n-u7W" firstAttribute="top" secondItem="ajT-fE-68f" secondAttribute="bottom" constant="10" id="efC-zX-omu"/>
                             <constraint firstItem="idB-yn-buE" firstAttribute="top" secondItem="qP8-o9-R2v" secondAttribute="bottom" constant="10" id="h1F-9S-E87"/>
+                            <constraint firstItem="n4y-da-19G" firstAttribute="leading" secondItem="idB-yn-buE" secondAttribute="leading" id="hDk-JA-FKF"/>
                             <constraint firstItem="qP8-o9-R2v" firstAttribute="top" secondItem="ddW-pd-P7F" secondAttribute="bottom" constant="20" id="hGq-7g-AoA"/>
                             <constraint firstItem="ObJ-i8-8CK" firstAttribute="trailing" secondItem="qP8-o9-R2v" secondAttribute="trailing" constant="20" id="lPj-st-dRf"/>
                             <constraint firstItem="ddW-pd-P7F" firstAttribute="leading" secondItem="ObJ-i8-8CK" secondAttribute="leading" constant="13" id="oll-Pe-uit"/>
@@ -135,6 +146,8 @@
                         <outlet property="contentView" destination="B5n-0n-u7W" id="chn-5B-5uJ"/>
                         <outlet property="markdownTextView" destination="hLS-Fq-LbG" id="wHi-bh-s3M"/>
                         <outlet property="segmentedControl" destination="ajT-fE-68f" id="Ym1-76-RFF"/>
+                        <outlet property="titleTextField" destination="qP8-o9-R2v" id="BwA-rh-asQ"/>
+                        <outlet property="titleTextFieldErrorLabel" destination="n4y-da-19G" id="rVm-T3-JKO"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="BxN-aQ-VwD" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -151,6 +164,9 @@
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemPinkColor">
+            <color red="1" green="0.17647058823529413" blue="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Controller/RegisterIssue/RegisterIssueViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/RegisterIssue/RegisterIssueViewController.swift
@@ -10,24 +10,79 @@ import MarkdownView
 
 final class RegisterIssueViewController: UIViewController, UINavigationControllerDelegate {
     
+    @IBOutlet var titleTextField: UITextField!
     @IBOutlet var contentView: UIView!
     @IBOutlet var markdownTextView: UITextView!
     @IBOutlet var segmentedControl: UISegmentedControl!
+    @IBOutlet var titleTextFieldErrorLabel: UILabel!
     
     var imageView: UIImageView!
     var markdownView: MarkdownView!
     var imagePicker = UIImagePickerController()
     
+    private let api = BackEndAPIManager(router: Router())
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        configureTextArea()
         addCustomMenu()
     }
     
     @IBAction func pressedDone(_ sender: UIButton) {
-        // 완료 버튼 누를 시 저장하고 화면을 닫는다.
-        dismiss(animated: true, completion: nil)
+        var title = ""
+        
+        do {
+            title = try titleTextField.validatedText(validationType: .requiredField(field: "제목"))
+        } catch (let error) {
+            alertValidationErrorOnSave(error: error)
+            return
+        }
+     
+        alertProceedSave(title: title, content: markdownTextView.text)
     }
+    
+    private func alertProceedSave(title: String, content: String) {
+        
+        let saveAlert = UIAlertController(title: "알림", message: "이슈을 저장하시겠습니까?", preferredStyle: UIAlertController.Style.alert)
+        
+        saveAlert.addAction(UIAlertAction(title: "OK", style: .default, handler: { (action: UIAlertAction!) in
+            self.registerNewIssue(title: title, content: content)
+
+            self.dismiss(animated: true, completion: nil)
+        }))
+        
+        saveAlert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        
+        present(saveAlert, animated: true, completion: nil)
+
+    }
+    
+    private func registerNewIssue(title: String, content: String) {
+        
+        api.addNewIssue(title: title, content: content) { result in
+            switch result {
+            case .success(let issue):
+                print(".success:", issue)
+                DispatchQueue.main.async {
+                    // TODO: 새 이슈를 이슈목록에 반영하기 .. delegate 사용?
+                }
+            case .failure(let error):
+                print(error)
+            }
+            
+        }
+    }
+    
+    private func alertValidationErrorOnSave(error: Error) {
+        
+        let validationErrorAlert = UIAlertController(title: "잠깐! 🤗", message: (error as! ValidationError).message, preferredStyle: .alert)
+        
+        validationErrorAlert.addAction(UIAlertAction(title: "OK", style: UIAlertAction.Style.default, handler: nil))
+        
+        self.present(validationErrorAlert, animated: true, completion: nil)
+    }
+    
     
     @IBAction func pressedClose(_ sender: UIButton) {
         dismiss(animated: true, completion: nil)
@@ -42,6 +97,21 @@ final class RegisterIssueViewController: UIViewController, UINavigationControlle
             markdownView.load(markdown: markdownTextView.text)
             switchView(markdownView)
         default: break;
+        }
+    }
+    
+    func configureTextArea() {
+        
+        titleTextField.addTarget(self, action: #selector(checkTitleTextField(textfield:)), for: .editingChanged)
+    }
+    
+    @objc private func checkTitleTextField (textfield: UITextField) {
+        
+        do {
+            try textfield.validatedText(validationType: .requiredField(field: "제목"))
+            titleTextFieldErrorLabel.text = ""
+        } catch (let error) {
+            titleTextFieldErrorLabel.text = (error as! ValidationError).message
         }
     }
     

--- a/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
@@ -30,6 +30,13 @@ class BackEndAPIManager {
         }
     }
     
+    func addNewIssue(title: String, content: String, completionHandler: @escaping ((Result<IssueInfo, APIError>) -> Void)) {
+       
+        router.request(route: BackEndAPI.addNewIssue(title: title, content: content)) { (result: Result<IssueInfo, APIError>) in
+            completionHandler(result)
+        }
+    }
+    
     // route: 작성자 or 레이블 or 마일스톤 or 담당자
     func requestDetailCondition<T: Decodable>(route: BackEndAPI, completionHandler: @escaping ((Result<T, APIError>) -> Void)) {
         router.request(route: route) { (result: Result<T, APIError>) in

--- a/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
@@ -16,6 +16,8 @@ enum BackEndAPI {
          allMilestones,
          allAssignees
  
+    case addNewIssue(title: String, content: String)
+    
     case addNewLabel(labelName: String, labelDescription: String, labelColor: String)
     case editExistingLabel(labelId: Int, labelName: String, labelDescription: String, labelColor: String)
 
@@ -31,7 +33,7 @@ extension BackEndAPI: EndPointable {
         switch self {
         case .token:
             return "http://\(BackEndAPICredentials.ip)/api/auth/github/ios"
-        case .allIssues:
+        case .allIssues, .addNewIssue:
             return "http://\(BackEndAPICredentials.ip)/api/issue"
         case .allLabels:
             return "http://\(BackEndAPICredentials.ip)/api/label"
@@ -76,7 +78,7 @@ extension BackEndAPI: EndPointable {
             return .get
         case .closeIssue:
             return .put
-        case .addNewLabel:
+        case .addNewLabel, .addNewIssue:
             return .post
         case .editExistingLabel:
             return .put
@@ -97,12 +99,10 @@ extension BackEndAPI: EndPointable {
         switch self {
         case .closeIssue(_, let title, let status):
             return ["title": "\(title)", "status":"\(status)"]
-        case .addNewLabel(let labelName, let labelDescription, let labelColor):
-            let bodyDictionary = ["name": labelName,
-                                  "description": labelDescription,
-                                  "color": labelColor]
-            return bodyDictionary
-        case .editExistingLabel(_, let labelName, let labelDescription, let labelColor):
+        case .addNewIssue(let title, let content):
+            return ["title": title, "content": content]
+        case .addNewLabel(let labelName, let labelDescription, let labelColor),
+             .editExistingLabel(_, let labelName, let labelDescription, let labelColor):
             let bodyDictionary = ["name": labelName,
                                   "description": labelDescription,
                                   "color": labelColor]


### PR DESCRIPTION
# 이슈 생성화면을 열 수 있다. part2

## 해당 이슈 📎

https://github.com/boostcamp-2020/IssueTracker-7/issues/96

## 변경 사항 🛠

구현내용 요약: 이슈 생성화면에서 이슈가 저장될 수 있도록 서버와 연결하였습니다. 그 외에 제목을 필수로 입력해야하는 validation 로직을 추가했습니다.

사실 이슈 생성화면 외에도 이슈 상세화면에서 이슈 수정화면으로 연결되고난 후에 저장하는 부분도 구현이 필요한 상태인데, 해당 부분은 섣불리 진행하면 충돌이 일어날 수 있기 때문에 상세화면의 틀이 만들어질때까지 대기하고자 합니다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

