### PR TITLE
카드뷰에서 커멘트를 할 수 있어야한다.

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -82,7 +82,6 @@
 		33BD8DE62549956B00537960 /* BackEndAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33BD8DE52549956B00537960 /* BackEndAPIManager.swift */; };
 		33DE7552255C5EFD00A92814 /* DetailIssueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7551255C5EFD00A92814 /* DetailIssueHeader.swift */; };
 		33DE7558255C64A300A92814 /* CardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7556255C64A300A92814 /* CardViewController.swift */; };
-		33DE7559255C64A300A92814 /* CardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33DE7557255C64A300A92814 /* CardViewController.xib */; };
 		712CBEA12550032F00E8F95F /* RegisterIssue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 712CBEA02550032F00E8F95F /* RegisterIssue.storyboard */; };
 		712CBEA6255008B700E8F95F /* RegisterIssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */; };
 		7130A690255163A700EE2141 /* ManageLabel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7130A68F255163A700EE2141 /* ManageLabel.storyboard */; };
@@ -93,6 +92,9 @@
 		7130A6D12552CD0F00EE2141 /* InputValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7130A6D02552CD0F00EE2141 /* InputValidator.swift */; };
 		71531F57254A859F00CCFAE2 /* IssueListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71531F56254A859F00CCFAE2 /* IssueListViewController.swift */; };
 		71531F60254A88F000CCFAE2 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71531F5F254A88F000CCFAE2 /* UIButton+.swift */; };
+		7179187E255CF4A30009496A /* CommentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7179187D255CF4A30009496A /* CommentViewController.swift */; };
+		71791883255CF9CD0009496A /* CommentView.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 71791882255CF9CD0009496A /* CommentView.storyboard */; };
+		71791897255D1ED90009496A /* CardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 71791896255D1ED90009496A /* CardViewController.xib */; };
 		718C388E2553E6E1002E4903 /* ManageMilestone.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 718C388D2553E6E1002E4903 /* ManageMilestone.storyboard */; };
 		718C38932553E6FB002E4903 /* ManageMilestoneViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */; };
 		718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 718C38972553E716002E4903 /* ManageMilestoneModalView.swift */; };
@@ -178,7 +180,6 @@
 		33BD8DE52549956B00537960 /* BackEndAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackEndAPIManager.swift; sourceTree = "<group>"; };
 		33DE7551255C5EFD00A92814 /* DetailIssueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueHeader.swift; sourceTree = "<group>"; };
 		33DE7556255C64A300A92814 /* CardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewController.swift; sourceTree = "<group>"; };
-		33DE7557255C64A300A92814 /* CardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardViewController.xib; sourceTree = "<group>"; };
 		712CBEA02550032F00E8F95F /* RegisterIssue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RegisterIssue.storyboard; sourceTree = "<group>"; };
 		712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterIssueViewController.swift; sourceTree = "<group>"; };
 		7130A68F255163A700EE2141 /* ManageLabel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ManageLabel.storyboard; sourceTree = "<group>"; };
@@ -189,6 +190,9 @@
 		7130A6D02552CD0F00EE2141 /* InputValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputValidator.swift; sourceTree = "<group>"; };
 		71531F56254A859F00CCFAE2 /* IssueListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IssueListViewController.swift; sourceTree = "<group>"; };
 		71531F5F254A88F000CCFAE2 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
+		7179187D255CF4A30009496A /* CommentViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentViewController.swift; sourceTree = "<group>"; };
+		71791882255CF9CD0009496A /* CommentView.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CommentView.storyboard; sourceTree = "<group>"; };
+		71791896255D1ED90009496A /* CardViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CardViewController.xib; sourceTree = "<group>"; };
 		718C388D2553E6E1002E4903 /* ManageMilestone.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ManageMilestone.storyboard; sourceTree = "<group>"; };
 		718C38922553E6FB002E4903 /* ManageMilestoneViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneViewController.swift; sourceTree = "<group>"; };
 		718C38972553E716002E4903 /* ManageMilestoneModalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManageMilestoneModalView.swift; sourceTree = "<group>"; };
@@ -398,7 +402,9 @@
 				333FE2A42551513F000C0F0B /* DetailIssueList.storyboard */,
 				333FE2A925515167000C0F0B /* DetailIssueListController.swift */,
 				33DE7556255C64A300A92814 /* CardViewController.swift */,
-				33DE7557255C64A300A92814 /* CardViewController.xib */,
+				71791896255D1ED90009496A /* CardViewController.xib */,
+				7179187D255CF4A30009496A /* CommentViewController.swift */,
+				71791882255CF9CD0009496A /* CommentView.storyboard */,
 			);
 			path = DetailIssueList;
 			sourceTree = "<group>";
@@ -671,7 +677,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33DE7559255C64A300A92814 /* CardViewController.xib in Resources */,
+				71791897255D1ED90009496A /* CardViewController.xib in Resources */,
 				719453B3254AAF6600A5864E /* IssueList.storyboard in Resources */,
 				33151F2725499E04006B94A9 /* NanumSquareBold.ttf in Resources */,
 				718C388E2553E6E1002E4903 /* ManageMilestone.storyboard in Resources */,
@@ -684,6 +690,7 @@
 				33375C432547E71000E8A8E8 /* Assets.xcassets in Resources */,
 				33375C412547E70E00E8A8E8 /* Main.storyboard in Resources */,
 				33151F2925499E04006B94A9 /* NanumSquareOTF_acEB.otf in Resources */,
+				71791883255CF9CD0009496A /* CommentView.storyboard in Resources */,
 				33493B4E2556632800BB1E11 /* IssueCellContentView.xib in Resources */,
 				333FE2A52551513F000C0F0B /* DetailIssueList.storyboard in Resources */,
 			);
@@ -730,6 +737,7 @@
 				3358A593254EEBDF008CEFA3 /* LabelConditionTableViewController.swift in Sources */,
 				33DE7558255C64A300A92814 /* CardViewController.swift in Sources */,
 				718C389D2553E72E002E4903 /* ManageMilestoneModalViewController.swift in Sources */,
+				7179187E255CF4A30009496A /* CommentViewController.swift in Sources */,
 				3358A57C254ED757008CEFA3 /* StoryboardID.swift in Sources */,
 				3393E0AC2552698C003DCDA4 /* UIView+.swift in Sources */,
 				33493B49255662B100BB1E11 /* IssueCellContentView.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
@@ -15,6 +15,9 @@ class CardViewController: UIViewController {
     @IBOutlet weak var baseView: UIView!
     @IBOutlet weak var closeButton: UIButton!
     
+    var commentViewControllerDelegate: CommentViewControllerDelegate?
+    var issueInfo: IssueInfo!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
@@ -37,6 +40,14 @@ class CardViewController: UIViewController {
         closeButton.layer.cornerRadius = 5
     }
 
-
-
+    @IBAction func pressedAddCommentButton(_ sender: UIButton) {
+        
+        let storyboard = UIStoryboard(name: "CommentView", bundle: nil)
+        let viewController = storyboard.instantiateViewController(identifier: "CommentViewController") as! CommentViewController
+        viewController.issueId = issueInfo.id
+        viewController.delegate = commentViewControllerDelegate
+        present(viewController, animated: true, completion: nil)
+    }
 }
+
+

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.xib
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.xib
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -42,6 +42,9 @@
                             </constraints>
                             <fontDescription key="fontDescription" type="system" pointSize="19"/>
                             <state key="normal" title="댓글 추가"/>
+                            <connections>
+                                <action selector="pressedAddCommentButton:" destination="-1" eventType="touchUpInside" id="bTC-3z-8Oo"/>
+                            </connections>
                         </button>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IOO-oK-3zB">
                             <rect key="frame" x="256" y="0.0" width="93" height="45"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentView.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentView.storyboard
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+    </dependencies>
+    <scenes/>
+</document>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentView.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentView.storyboard
@@ -1,7 +1,73 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13142" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12042"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
-    <scenes/>
+    <scenes>
+        <!--Comment View Controller-->
+        <scene sceneID="Fg8-v2-kXe">
+            <objects>
+                <viewController storyboardIdentifier="CommentViewController" id="mwU-8t-65T" customClass="CommentViewController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="k2I-Tc-0rI">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="12o-VK-d7m">
+                                <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                <items>
+                                    <navigationItem title="댓글" id="XR3-4Q-1xg">
+                                        <barButtonItem key="leftBarButtonItem" title="취소" id="PPB-1Y-xVe">
+                                            <connections>
+                                                <action selector="pressedCancel:" destination="mwU-8t-65T" id="42R-OD-vrR"/>
+                                            </connections>
+                                        </barButtonItem>
+                                        <barButtonItem key="rightBarButtonItem" title="저장" id="1zS-n4-Uzl">
+                                            <connections>
+                                                <action selector="pressedSave:" destination="mwU-8t-65T" id="CJa-td-Atn"/>
+                                            </connections>
+                                        </barButtonItem>
+                                    </navigationItem>
+                                </items>
+                            </navigationBar>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="WpH-D7-Tsb">
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="textColor" systemColor="labelColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="icS-9f-Kb8"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="WpH-D7-Tsb" firstAttribute="top" secondItem="12o-VK-d7m" secondAttribute="bottom" id="5l8-Mv-aPg"/>
+                            <constraint firstItem="12o-VK-d7m" firstAttribute="top" secondItem="icS-9f-Kb8" secondAttribute="top" id="6zM-s6-RoG"/>
+                            <constraint firstItem="12o-VK-d7m" firstAttribute="leading" secondItem="icS-9f-Kb8" secondAttribute="leading" id="SAA-RO-goB"/>
+                            <constraint firstItem="12o-VK-d7m" firstAttribute="trailing" secondItem="icS-9f-Kb8" secondAttribute="trailing" id="TKQ-ua-SkZ"/>
+                            <constraint firstItem="icS-9f-Kb8" firstAttribute="trailing" secondItem="WpH-D7-Tsb" secondAttribute="trailing" id="pgm-rN-UIq"/>
+                            <constraint firstItem="WpH-D7-Tsb" firstAttribute="leading" secondItem="icS-9f-Kb8" secondAttribute="leading" id="s8a-ev-apS"/>
+                            <constraint firstItem="icS-9f-Kb8" firstAttribute="bottom" secondItem="WpH-D7-Tsb" secondAttribute="bottom" id="wR0-9B-rD1"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="commentTextview" destination="WpH-D7-Tsb" id="uIB-Qv-zQa"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="uak-JR-erf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-101" y="110"/>
+        </scene>
+    </scenes>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentViewController.swift
@@ -7,16 +7,22 @@
 
 import UIKit
 
+protocol CommentViewControllerDelegate: AnyObject {
+    
+    func appendComment(comment: Comment)
+}
+
 final class CommentViewController: UIViewController {
+    
+    private let api = BackEndAPIManager(router: Router())
+    weak var delegate: CommentViewControllerDelegate?
+    var issueId: Int? = nil
     
     @IBOutlet var commentTextview: UITextView!
     
-    
     override func viewDidLoad() {
         super.viewDidLoad()
-    }
     
-    private func commonInitializer() {
         configureTextview()
     }
     
@@ -24,7 +30,33 @@ final class CommentViewController: UIViewController {
         commentTextview.delegate = self
     }
     
+    @IBAction func pressedCancel(_ sender: UIButton) {
+        
+        dismiss(animated: true, completion: nil)
+    }
     
+    @IBAction func pressedSave(_ sender: UIButton) {
+        
+        guard let issueId = issueId else { return }
+        
+        api.addComment(issueId: issueId, content: commentTextview.text )  { result in
+            switch result {
+            case .success(let comment):
+                DispatchQueue.main.async {
+                    self.delegate?.appendComment(comment: comment)
+                    // TODO: comment를 상세화면으로 전달하여 추가해주기 delegate 이용?
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
+        dismiss(animated: true, completion: nil)
+    }
+    
+    private func addComment() {
+        
+        
+    }
 }
 
 extension CommentViewController: UITextViewDelegate {

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CommentViewController.swift
@@ -1,0 +1,45 @@
+//
+//  CommentView.swift
+//  IssueTracker
+//
+//  Created by Imho Jang on 2020/11/12.
+//
+
+import UIKit
+
+final class CommentViewController: UIViewController {
+    
+    @IBOutlet var commentTextview: UITextView!
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    private func commonInitializer() {
+        configureTextview()
+    }
+    
+    private func configureTextview () {
+        commentTextview.delegate = self
+    }
+    
+    
+}
+
+extension CommentViewController: UITextViewDelegate {
+    
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if commentTextview.textColor == .lightGray && commentTextview.isFirstResponder {
+            commentTextview.text = nil
+            commentTextview.textColor = .black
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if commentTextview.text.isEmpty || commentTextview.text == "" {
+            commentTextview.textColor = .lightGray
+            commentTextview.text = "이곳에 댓글을 작성해주세요."
+        }
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -25,7 +25,7 @@ final class DetailIssueListController: UIViewController {
     
     private let api = BackEndAPIManager(router: Router())
     
-    private let issueInfo: IssueInfo!
+    private var issueInfo: IssueInfo!
     private var commentsInfoList: [Comment]!
     
     private let cardView = CardViewController(nibName: "CardViewController", bundle: nil)
@@ -139,6 +139,9 @@ extension DetailIssueListController {
         cardView.view.layer.cornerRadius = 15.0
         cardView.view.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         
+        cardView.issueInfo = issueInfo
+        cardView.commentViewControllerDelegate = self
+        
         // Pan 제스쳐 설정
         addGesture()
     }
@@ -221,6 +224,25 @@ extension DetailIssueListController {
         
         cardLatestY = baseView.frame.origin.y
         frameAnimator.startAnimation()
+    }
+}
+
+extension DetailIssueListController: CommentViewControllerDelegate {
+    
+    func appendComment(comment: Comment) {
+        
+        issueInfo.comments?.append(comment)
+        
+        let lastItemIndex = self.collectionView.numberOfItems(inSection: 0) - 1
+        let lastItemIndexPath = IndexPath(item: lastItemIndex, section: 0)
+        
+        print("DetailIssueController, appendingComment:", comment)
+        self.collectionView.performBatchUpdates {
+            collectionView.insertItems(at: [lastItemIndexPath])
+        } completion: { _ in
+            self.collectionView.scrollToItem(at: lastItemIndexPath, at: .bottom, animated: true)
+        }
+
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -39,7 +39,7 @@ final class DetailIssueListController: UIViewController {
         dimmerView.frame = self.view.bounds
         return dimmerView
     }()
-
+    
     private lazy var cardMinimumY: CGFloat = view.bounds.height * 0.1
     private lazy var cardMaximumY: CGFloat = view.bounds.height * 0.85
     
@@ -96,7 +96,7 @@ final class DetailIssueListController: UIViewController {
 
 // MARK: 카드뷰(풀업뷰)
 extension DetailIssueListController {
-        
+    
     private func setUpDimmerView() {
         dimmerView.isUserInteractionEnabled = false
         dimmerView.alpha = 0
@@ -149,9 +149,9 @@ extension DetailIssueListController {
     @objc private func dimmerViewTapped() {
         animateCardView(to: .collapsed, withDuration: 0.1) // 최소화
     }
-        
+    
     @objc private func baseViewPanned (recognizer:UIPanGestureRecognizer) {
-
+        
         dimmerView.alpha = (1 - (baseView.frame.origin.y - cardMinimumY) / (cardMaximumY - cardMinimumY)) * maximumAlpha
         
         switch recognizer.state {
@@ -174,7 +174,7 @@ extension DetailIssueListController {
                 animateCardView(to: .expanded, withDuration: 0.2, bounce: bounce)
                 return
             }
-    
+            
             // CardView Y 좌표 기준 자동 확대 / 축소
             let cardMidY = cardMinimumY + (cardMaximumY - cardMinimumY) / 2
             
@@ -202,7 +202,7 @@ extension DetailIssueListController {
                 self.baseView.frame.origin.y = self.cardMaximumY + bounce
                 self.dimmerView.isUserInteractionEnabled = false
                 self.dimmerView.alpha = 0
-        
+                
                 self.cardCurrentState = .collapsed
             }
         }
@@ -231,18 +231,22 @@ extension DetailIssueListController: CommentViewControllerDelegate {
     
     func appendComment(comment: Comment) {
         
-        issueInfo.comments?.append(comment)
+        commentsInfoList.append(comment)
         
         let lastItemIndex = self.collectionView.numberOfItems(inSection: 0) - 1
         let lastItemIndexPath = IndexPath(item: lastItemIndex, section: 0)
         
-        print("DetailIssueController, appendingComment:", comment)
-        self.collectionView.performBatchUpdates {
-            collectionView.insertItems(at: [lastItemIndexPath])
-        } completion: { _ in
-            self.collectionView.scrollToItem(at: lastItemIndexPath, at: .bottom, animated: true)
-        }
-
+        reloadSnapshot(completionHandler: {
+            self.collectionView.scrollToItem(at: lastItemIndexPath, at: .centeredVertically, animated: false)
+        })
+    }
+    
+    func reloadSnapshot(completionHandler: () -> Void) {
+        var snapshot = NSDiffableDataSourceSnapshot<Section, Comment>()
+        snapshot.appendSections([.main])
+        snapshot.appendItems(commentsInfoList)
+        dataSource?.apply(snapshot, animatingDifferences: true)
+        completion()
     }
 }
 
@@ -252,7 +256,7 @@ extension DetailIssueListController: CommentViewControllerDelegate {
 extension DetailIssueListController {
     
     private func createLayout() -> UICollectionViewLayout {
-
+        
         let heightDimension = NSCollectionLayoutDimension.estimated(500)
         
         let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: heightDimension)
@@ -301,7 +305,7 @@ extension DetailIssueListController {
                     }
                 }
             }
-
+            
             return cell
         }
         

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -246,7 +246,7 @@ extension DetailIssueListController: CommentViewControllerDelegate {
         snapshot.appendSections([.main])
         snapshot.appendItems(commentsInfoList)
         dataSource?.apply(snapshot, animatingDifferences: true)
-        completion()
+        completionHandler()
     }
 }
 

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -9,15 +9,19 @@ import UIKit
 
 final class ManageMilestoneViewController: UIViewController, UICollectionViewDelegate {
     
+    //MARK:- IBOutlets
     @IBOutlet var collectionView: UICollectionView!
+    
+    //MARK:- Properties
     private var milestoneDataList: [MilestoneInfo] = []
     private let api = BackEndAPIManager(router: Router())
     
+    //MARK:- View Cycle
     override func viewDidLoad() {
         super.viewDidLoad()
         setUpMilestoneData()
         
-      Layout()
+        configureLayout()
         collectionView.dataSource = self
         collectionView.delegate = self
     }
@@ -138,8 +142,8 @@ final class MilestoneCell: UICollectionViewCell {
     @IBOutlet var closedIssueCount: UILabel!
         
     fileprivate func configure(milestoneData: MilestoneInfo) {
-        let numberOfOpenIssues = milestoneData.issues.filter { $0.status == "open" }.count
-        let numberOfClosedIssues = milestoneData.issues.filter { $0.status == "closed" }.count
+        guard let numberOfOpenIssues = milestoneData.issues?.filter { $0.status == "open" }.count,
+              let numberOfClosedIssues = milestoneData.issues?.filter { $0.status == "closed" }.count else { return }
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .percent
         numberFormatter.locale = Locale(identifier: "en_US")

--- a/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
@@ -105,4 +105,12 @@ class BackEndAPIManager {
 
         }
     }
+    
+    func addComment(issueId: Int, content: String, completionHandler: @escaping ((Result<Comment, APIError>) -> Void)) {
+        router.request(route: BackEndAPI.addComment(issueId: issueId, content: content)) { (result: Result<Comment, APIError>) in
+            
+            completionHandler(result)
+            
+        }
+    }
 }

--- a/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
@@ -28,6 +28,8 @@ enum BackEndAPI {
     case closeIssue(issueNumber: String, title: String, status: String)
     
     case photo(path: String)
+    
+    case addComment(issueId: Int, content: String)
 }
 
 extension BackEndAPI: EndPointable {
@@ -57,6 +59,8 @@ extension BackEndAPI: EndPointable {
             return "http://\(BackEndAPICredentials.ip)/api/milestone/\(milestoneId)"
         case .photo(let path):
             return "\(path)"
+        case .addComment(let issueId, _):
+            return "http://\(BackEndAPICredentials.ip)/api/issue/\(issueId)/comment"
         }
     }
     
@@ -82,7 +86,7 @@ extension BackEndAPI: EndPointable {
             return .get
         case .closeIssue:
             return .put
-        case .addNewLabel, .addNewIssue:
+        case .addNewLabel, .addNewIssue, .addComment:
             return .post
         case .editExistingLabel:
             return .put
@@ -119,6 +123,8 @@ extension BackEndAPI: EndPointable {
                                   "due_date": milestoneDueDate,
                                   "description": milestoneDescription]
             return bodyDictionary
+        case .addComment(_, let content):
+            return ["content": content]
         default:
             return nil
         }

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
@@ -12,7 +12,7 @@ struct Comment: Codable {
     let content, updatedAt: String
     let deletedAt, createdAt: String?
     let userID: Int?
-    let issueID: Int
+    let issueID: Int?
     let mentions: Assignee?
 
     enum CodingKeys: String, CodingKey {

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct Comment: Codable {
     let id: Int
-    let content, createdAt, updatedAt: String
-    let deletedAt: String?
+    let content, updatedAt: String
+    let deletedAt, createdAt: String?
     let userID: Int?
     let issueID: Int
     let mentions: Assignee?
@@ -18,7 +18,7 @@ struct Comment: Codable {
     enum CodingKeys: String, CodingKey {
         case id, content
         case createdAt
-        case updatedAt
+        case updatedAt = "updated_at"
         case deletedAt
         case userID = "user_id"
         case issueID = "issue_id"

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
@@ -14,8 +14,9 @@ struct MilestonesInfo: Codable {
 // MARK: - Milestone
 struct MilestoneInfo: Codable {
     let id: Int
-    let title, dueDate, description: String
-    let issues: [IssuesInMilestone]
+    let title, dueDate: String
+    let description: String?
+    let issues: [IssuesInMilestone]?
   
     enum CodingKeys: String, CodingKey {
         case id, title, description, issues
@@ -26,4 +27,5 @@ struct MilestoneInfo: Codable {
 struct IssuesInMilestone: Codable {
     let id: Int
     let title, status: String
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
@@ -20,7 +20,7 @@ struct IssueInfo: Codable {
     let labels: [LabelInfo]?
     let assignees: [Assignee]?
     let author: Author?
-    let comments: [Comment]?
+    var comments: [Comment]?
     let milestone: MilestoneInfo?
 
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
# 카드뷰에서 커멘트를 할 수 있어야한다.

## 해당 이슈 📎

https://github.com/boostcamp-2020/IssueTracker-7/issues/239

## 변경 사항 🛠

댓글 작성할 수 있는 화면인 CommentViewController 생성. 뷰를 코드로 적기 보단 스토리보드로 만들고 싶어서 커멘트뷰 스토리보드 생성.

이슈 상세화면 -> 카드뷰 -> 커멘트 뷰 delegate 설정해주고 delegate를 통해 서버 응답으로 받은 comment 를 전달하고 이어붙여준다.

이슈 상세화면의 컬렉션뷰는 diffable을 사용하기 때문에 reload snapshot을 이용하여 업데이트를 해준다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

