### PR TITLE
이슈의 담당자를 조회/변경할 수 있다.

### DIFF
--- a/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
+++ b/iOS/IssueTracker/IssueTracker.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		33DE7552255C5EFD00A92814 /* DetailIssueHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7551255C5EFD00A92814 /* DetailIssueHeader.swift */; };
 		33DE7558255C64A300A92814 /* CardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7556255C64A300A92814 /* CardViewController.swift */; };
 		33DE7559255C64A300A92814 /* CardViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33DE7557255C64A300A92814 /* CardViewController.xib */; };
+		33DE7562255CDC2B00A92814 /* AssigneeSelectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7561255CDC2B00A92814 /* AssigneeSelectController.swift */; };
+		33DE757A255D1C7400A92814 /* AssigneesProfileStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33DE7579255D1C7400A92814 /* AssigneesProfileStackView.swift */; };
 		712CBEA12550032F00E8F95F /* RegisterIssue.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 712CBEA02550032F00E8F95F /* RegisterIssue.storyboard */; };
 		712CBEA6255008B700E8F95F /* RegisterIssueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */; };
 		7130A690255163A700EE2141 /* ManageLabel.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7130A68F255163A700EE2141 /* ManageLabel.storyboard */; };
@@ -179,6 +181,8 @@
 		33DE7551255C5EFD00A92814 /* DetailIssueHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailIssueHeader.swift; sourceTree = "<group>"; };
 		33DE7556255C64A300A92814 /* CardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardViewController.swift; sourceTree = "<group>"; };
 		33DE7557255C64A300A92814 /* CardViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CardViewController.xib; sourceTree = "<group>"; };
+		33DE7561255CDC2B00A92814 /* AssigneeSelectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneeSelectController.swift; sourceTree = "<group>"; };
+		33DE7579255D1C7400A92814 /* AssigneesProfileStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssigneesProfileStackView.swift; sourceTree = "<group>"; };
 		712CBEA02550032F00E8F95F /* RegisterIssue.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = RegisterIssue.storyboard; sourceTree = "<group>"; };
 		712CBEA5255008B700E8F95F /* RegisterIssueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterIssueViewController.swift; sourceTree = "<group>"; };
 		7130A68F255163A700EE2141 /* ManageLabel.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ManageLabel.storyboard; sourceTree = "<group>"; };
@@ -376,6 +380,7 @@
 		33375CB5254879B200E8A8E8 /* View */ = {
 			isa = PBXGroup;
 			children = (
+				33DE7579255D1C7400A92814 /* AssigneesProfileStackView.swift */,
 				3393E0A6255253C2003DCDA4 /* AppleSignInButton */,
 				3393E0D025530B0B003DCDA4 /* Cell */,
 			);
@@ -399,6 +404,7 @@
 				333FE2A925515167000C0F0B /* DetailIssueListController.swift */,
 				33DE7556255C64A300A92814 /* CardViewController.swift */,
 				33DE7557255C64A300A92814 /* CardViewController.xib */,
+				33DE7561255CDC2B00A92814 /* AssigneeSelectController.swift */,
 			);
 			path = DetailIssueList;
 			sourceTree = "<group>";
@@ -738,6 +744,7 @@
 				3358A574254D1D5F008CEFA3 /* BackEndAPI.swift in Sources */,
 				339F611E2553FF7B00FDB2A9 /* DetailIssueCell.swift in Sources */,
 				33493BAB255849F200BB1E11 /* JsonFactory.swift in Sources */,
+				33DE757A255D1C7400A92814 /* AssigneesProfileStackView.swift in Sources */,
 				334D0F1B255A4A9F001DE5B4 /* MileStoneConditionTableViewController.swift in Sources */,
 				3393E0BD2552AACC003DCDA4 /* IssueInfo.swift in Sources */,
 				3393E0D225530B33003DCDA4 /* IssueCell.swift in Sources */,
@@ -759,6 +766,7 @@
 				339892B22549876B00D9FB63 /* UserInfo.swift in Sources */,
 				7130A6CC2552A2A700EE2141 /* UIColor+.swift in Sources */,
 				718C38982553E716002E4903 /* ManageMilestoneModalView.swift in Sources */,
+				33DE7562255CDC2B00A92814 /* AssigneeSelectController.swift in Sources */,
 				3322CFAA2553B8900022ABA6 /* AppleSignInButton.swift in Sources */,
 				339892A125497CB400D9FB63 /* UserDefault.swift in Sources */,
 				71531F60254A88F000CCFAE2 /* UIButton+.swift in Sources */,

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/AssigneeSelectController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/AssigneeSelectController.swift
@@ -1,0 +1,137 @@
+//
+//  AssigneeSelectController.swift
+//  IssueTracker
+//
+//  Created by a1111 on 2020/11/12.
+//
+
+import UIKit
+
+protocol SendAssigneeDelegate: AnyObject {
+    func send(newAssignees: [Assignee])
+}
+
+class AssigneeSelectController: UIViewController {
+
+    // MARK: - Property
+    
+    @IBOutlet weak var tableView: UITableView!
+    
+    private let route: BackEndAPI = BackEndAPI.allAssignees
+    private let api = BackEndAPIManager(router: Router())
+    
+    private var unselectedAssignees: Set<Assignee> = []
+    var selectedAssignees: [Assignee] = []
+    var sectionsInfo: [[Assignee]] = []
+    private let sectionsTitle = ["지정 담당자", "미지정"]
+    
+    weak var delegate: SendAssigneeDelegate?
+    
+    
+    // MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        
+        configureInitialData()
+    }
+    
+    
+    // MARK: - Method
+    
+    func configureInitialData() {
+        api.requestDetailCondition(route: route) { (result: Result<[Assignee], APIError>) in
+            
+            switch result {
+            case .success(let assigneeInfoList):
+                let unselectedAssignees = Set(assigneeInfoList).subtracting(Set(self.selectedAssignees))
+                
+                // 지정된 담당자는 선택순서, 미지정된 담당자는 알파벳 순서대로
+                let sortedUnSelected = unselectedAssignees.sorted { $0.userID < $1.userID }
+                
+                self.sectionsInfo.append(self.selectedAssignees)
+                self.sectionsInfo.append(sortedUnSelected)
+                
+                DispatchQueue.main.async {
+                    self.tableView.reloadData()
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    @IBAction func cancelButtonTapped(_ sender: Any) {
+        dismiss(animated: true)
+    }
+    
+    @IBAction func doneButtonTapped(_ sender: Any) {
+        delegate?.send(newAssignees: sectionsInfo[0])
+        
+        dismiss(animated: true)
+    }
+    
+}
+
+
+// MARK: - Extension
+
+// MARK: 테이블뷰 DataSource
+extension AssigneeSelectController: UITableViewDataSource {
+    
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return sectionsInfo.count
+    }
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        sectionsInfo[section].count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: AssigneeCell.reuseIdentifier)
+                as? AssigneeCell else { return UITableViewCell() }
+        
+        cell.configure(by: sectionsInfo[indexPath.section][indexPath.row])
+    
+        return cell
+    }
+    
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        sectionsTitle[section]
+    }
+}
+
+// MARK: 테이블뷰 Delegate
+extension AssigneeSelectController: UITableViewDelegate {
+    
+    func change(index: Int, ofSection section1: Int, toSection section2: Int) {
+        let unselected = sectionsInfo[section1].remove(at: index)
+        sectionsInfo[section2].append(unselected)
+        sectionsInfo[section2].sort { $0.userID < $1.userID }
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch indexPath.section {
+        case 0:
+            change(index: indexPath.row, ofSection: 0, toSection: 1)
+        case 1:
+            change(index: indexPath.row, ofSection: 1, toSection: 0)
+        default:
+            break
+        }
+        tableView.reloadSections(IndexSet(integersIn: 0...1), with: .automatic)
+    }
+}
+
+
+class AssigneeCell: UITableViewCell {
+    static let reuseIdentifier = String(describing: AssigneeCell.self)
+    @IBOutlet weak var userID: UILabel!
+    
+    func configure(by assigneeInfo: Assignee) {
+        userID.text = assigneeInfo.userID
+
+    }
+}

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/AssigneeSelectController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/AssigneeSelectController.swift
@@ -15,14 +15,14 @@ class AssigneeSelectController: UIViewController {
 
     // MARK: - Property
     
-    @IBOutlet weak var tableView: UITableView!
+    @IBOutlet private weak var tableView: UITableView!
     
     private let route: BackEndAPI = BackEndAPI.allAssignees
     private let api = BackEndAPIManager(router: Router())
     
     private var unselectedAssignees: Set<Assignee> = []
     var selectedAssignees: [Assignee] = []
-    var sectionsInfo: [[Assignee]] = []
+    private var sectionsInfo: [[Assignee]] = []
     private let sectionsTitle = ["지정 담당자", "미지정"]
     
     weak var delegate: SendAssigneeDelegate?
@@ -33,14 +33,13 @@ class AssigneeSelectController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        
         configureInitialData()
     }
     
     
     // MARK: - Method
     
-    func configureInitialData() {
+    private func configureInitialData() {
         api.requestDetailCondition(route: route) { (result: Result<[Assignee], APIError>) in
             
             switch result {
@@ -62,16 +61,14 @@ class AssigneeSelectController: UIViewController {
         }
     }
     
-    @IBAction func cancelButtonTapped(_ sender: Any) {
+    @IBAction private func cancelButtonTapped(_ sender: Any) {
         dismiss(animated: true)
     }
     
-    @IBAction func doneButtonTapped(_ sender: Any) {
+    @IBAction private func doneButtonTapped(_ sender: Any) {
         delegate?.send(newAssignees: sectionsInfo[0])
-        
         dismiss(animated: true)
     }
-    
 }
 
 
@@ -132,6 +129,5 @@ class AssigneeCell: UITableViewCell {
     
     func configure(by assigneeInfo: Assignee) {
         userID.text = assigneeInfo.userID
-
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
@@ -8,17 +8,32 @@
 import UIKit
 
 class CardViewController: UIViewController {
-
+    
+    // MARK: - Property
+    
+    private let api = BackEndAPIManager(router: Router())
+    
     @IBOutlet weak var handle: UIView!
     @IBOutlet weak var commentAddBtn: UIButton!
     @IBOutlet weak var commentUpDownStackView: UIStackView!
     @IBOutlet weak var baseView: UIView!
     @IBOutlet weak var closeButton: UIButton!
     
+    @IBOutlet weak var assigneeStackView: AssigneesProfileStackView!
+    
+    var issueInfo: IssueInfo?
+    
+    
+    // MARK: - Life Cycle
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
         setUpViews()
+        
+        if let assignees = issueInfo?.assignees {
+            reloadAssigneeProfiles(assignees: assignees)
+        }
     }
     
     func setUpViews() {
@@ -26,7 +41,7 @@ class CardViewController: UIViewController {
         
         commentAddBtn.setUpShadow()
         commentAddBtn.layer.cornerRadius = 5
-
+        
         baseView.backgroundColor = UIColor.clear
         baseView.setUpShadow()
         
@@ -36,7 +51,96 @@ class CardViewController: UIViewController {
         closeButton.setUpShadow()
         closeButton.layer.cornerRadius = 5
     }
-
-
-
 }
+
+
+// MARK: - Extension
+
+// MARK: 담당자(Assignee)
+extension CardViewController {
+    func reloadAssigneeProfiles(assignees: [Assignee]) {
+        
+        let group = DispatchGroup()
+        
+        var assignees = assignees
+        assignees.enumerated().forEach { (index, assignee) in
+            if let url = assignee.photoURL {
+                group.enter()
+                api.requestPhoto(path: url) { result in
+                    switch result {
+                    case .success(let imageData):
+                        assignees[index].data = imageData
+                    case .failure(let error):
+                        print(error)
+                    }
+                    group.leave()
+                }
+            }
+        }
+        
+        group.notify(queue: .main) {
+            self.assigneeStackView.configure(by: assignees)
+        }
+    }
+    
+    
+    @IBAction func editAssignees(_ sender: Any) {
+        
+        let storyboard = UIStoryboard(name: "DetailIssueList", bundle: nil)
+        
+        guard let navigationController = storyboard.instantiateViewController(
+                identifier: "AssigneeNavigationController") as? UINavigationController,
+              let viewController = navigationController.topViewController as? AssigneeSelectController
+        else { return }
+        
+        viewController.delegate = self
+        if let assignees = issueInfo?.assignees {
+            viewController.selectedAssignees = assignees
+        }
+        navigationController.modalPresentationStyle = .pageSheet
+        present(navigationController, animated: true)
+    }
+}
+
+extension CardViewController: SendAssigneeDelegate {
+    
+    func updateBackEnd(of issueNumber: Int, by originAssignees: Set<Assignee>, and newAssignees: Set<Assignee>) {
+        
+        // 원본 - 새 담당자 = 빼야 할 담당자들
+        let deletedAssignees = originAssignees.subtracting(newAssignees)
+        deletedAssignees.forEach { assignee in
+            api.requestDeleteAssignee(issueNumber: "\(issueNumber)", userID: assignee.id) { result in
+                switch result {
+                case .success(let assignee):
+                    print(assignee)
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+        
+        let addedAssignees = Set(newAssignees).subtracting(Set(originAssignees))
+        addedAssignees.forEach { assignee in
+            api.requestAddAssignee(issueNumber: "\(issueNumber)", userID: assignee.id) { result in
+                switch result {
+                case .success(let assignee):
+                    print(assignee)
+                case .failure(let error):
+                    print(error)
+                }
+            }
+        }
+    }
+    
+    func send(newAssignees: [Assignee]) {
+        
+        guard let originAssignees = issueInfo?.assignees, let issueNumber = issueInfo?.id else { return }
+        
+        updateBackEnd(of: issueNumber, by: Set(originAssignees), and: Set(newAssignees))
+        
+        self.assigneeStackView.initializeView()
+        self.reloadAssigneeProfiles(assignees: newAssignees)
+        self.issueInfo?.assignees = newAssignees
+    }
+}
+

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.swift
@@ -13,11 +13,11 @@ class CardViewController: UIViewController {
     
     private let api = BackEndAPIManager(router: Router())
     
-    @IBOutlet weak var handle: UIView!
-    @IBOutlet weak var commentAddBtn: UIButton!
-    @IBOutlet weak var commentUpDownStackView: UIStackView!
-    @IBOutlet weak var baseView: UIView!
-    @IBOutlet weak var closeButton: UIButton!
+    @IBOutlet private weak var handle: UIView!
+    @IBOutlet private weak var commentAddBtn: UIButton!
+    @IBOutlet private weak var commentUpDownStackView: UIStackView!
+    @IBOutlet private weak var baseView: UIView!
+    @IBOutlet private weak var closeButton: UIButton!
     
     @IBOutlet weak var assigneeStackView: AssigneesProfileStackView!
     
@@ -58,7 +58,7 @@ class CardViewController: UIViewController {
 
 // MARK: 담당자(Assignee)
 extension CardViewController {
-    func reloadAssigneeProfiles(assignees: [Assignee]) {
+    private func reloadAssigneeProfiles(assignees: [Assignee]) {
         
         let group = DispatchGroup()
         
@@ -84,7 +84,7 @@ extension CardViewController {
     }
     
     
-    @IBAction func editAssignees(_ sender: Any) {
+    @IBAction private func editAssignees(_ sender: Any) {
         
         let storyboard = UIStoryboard(name: "DetailIssueList", bundle: nil)
         
@@ -104,7 +104,7 @@ extension CardViewController {
 
 extension CardViewController: SendAssigneeDelegate {
     
-    func updateBackEnd(of issueNumber: Int, by originAssignees: Set<Assignee>, and newAssignees: Set<Assignee>) {
+    private func updateBackEnd(of issueNumber: Int, by originAssignees: Set<Assignee>, and newAssignees: Set<Assignee>) {
         
         // 원본 - 새 담당자 = 빼야 할 담당자들
         let deletedAssignees = originAssignees.subtracting(newAssignees)

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.xib
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/CardViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CardViewController" customModule="IssueTracker" customModuleProvider="target">
             <connections>
+                <outlet property="assigneeStackView" destination="zjp-Rf-XIT" id="YP8-nm-qZs"/>
                 <outlet property="baseView" destination="IOO-oK-3zB" id="KVU-c0-218"/>
                 <outlet property="closeButton" destination="gcd-JD-ONL" id="Rpy-ra-awm"/>
                 <outlet property="commentAddBtn" destination="HRs-yv-1Gc" id="Xmq-5j-Anu"/>
@@ -79,11 +80,11 @@
                         </view>
                     </subviews>
                 </stackView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h1E-cB-8ea" userLabel="담당자 View">
-                    <rect key="frame" x="15" y="97" width="349" height="128"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h1E-cB-8ea" userLabel="담당자 View">
+                    <rect key="frame" x="15" y="97" width="349" height="51"/>
                     <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Rip-IW-WHk" userLabel="seperator">
-                            <rect key="frame" x="0.0" y="127" width="349" height="1"/>
+                        <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Rip-IW-WHk" userLabel="seperator">
+                            <rect key="frame" x="0.0" y="50" width="349" height="1"/>
                             <color key="backgroundColor" systemColor="systemGray4Color"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="1" id="3Jg-oR-HQ1"/>
@@ -95,43 +96,33 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="person.crop.square" catalog="system" translatesAutoresizingMaskIntoConstraints="NO" id="Czh-nh-W2B">
-                            <rect key="frame" x="0.0" y="34" width="65" height="57.5"/>
-                            <color key="tintColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="65" id="Coq-Zq-RDI"/>
-                                <constraint firstAttribute="width" secondItem="Czh-nh-W2B" secondAttribute="height" multiplier="1:1" constant="5" id="p6n-0Z-pNe"/>
-                            </constraints>
-                        </imageView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="id" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9cK-v9-bGL">
-                            <rect key="frame" x="26.5" y="103" width="12" height="17"/>
-                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                            <color key="textColor" systemColor="systemGrayColor"/>
-                            <nil key="highlightedColor"/>
-                        </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eoe-e8-lXt">
                             <rect key="frame" x="319" y="0.0" width="30" height="30"/>
                             <state key="normal" title="수정"/>
+                            <connections>
+                                <action selector="editAssignees:" destination="-1" eventType="touchUpInside" id="gVJ-dd-1uz"/>
+                            </connections>
                         </button>
+                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="zjp-Rf-XIT" userLabel="최상위 스택뷰" customClass="AssigneesProfileStackView" customModule="IssueTracker" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="34" width="0.0" height="0.0"/>
+                        </stackView>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <constraints>
-                        <constraint firstAttribute="bottom" secondItem="9cK-v9-bGL" secondAttribute="bottom" constant="8" id="5Ci-H0-uuc"/>
-                        <constraint firstItem="Czh-nh-W2B" firstAttribute="leading" secondItem="h1E-cB-8ea" secondAttribute="leading" id="7j6-FQ-Rq2"/>
+                        <constraint firstItem="Rip-IW-WHk" firstAttribute="top" secondItem="zjp-Rf-XIT" secondAttribute="bottom" constant="16" id="9ut-fl-q6k"/>
                         <constraint firstAttribute="trailing" secondItem="Rip-IW-WHk" secondAttribute="trailing" id="AAk-qi-aqX"/>
-                        <constraint firstItem="9cK-v9-bGL" firstAttribute="top" secondItem="Czh-nh-W2B" secondAttribute="bottom" constant="10" id="COO-yl-T90"/>
                         <constraint firstItem="2ns-ac-Nxb" firstAttribute="top" secondItem="h1E-cB-8ea" secondAttribute="top" id="LJX-Al-u6g"/>
-                        <constraint firstItem="Czh-nh-W2B" firstAttribute="top" secondItem="2ns-ac-Nxb" secondAttribute="bottom" constant="9" id="XFY-Uc-G3G"/>
                         <constraint firstItem="eoe-e8-lXt" firstAttribute="top" secondItem="h1E-cB-8ea" secondAttribute="top" id="bGM-yV-Ihb"/>
                         <constraint firstAttribute="trailing" secondItem="eoe-e8-lXt" secondAttribute="trailing" id="beV-mc-QHF"/>
-                        <constraint firstItem="9cK-v9-bGL" firstAttribute="centerX" secondItem="Czh-nh-W2B" secondAttribute="centerX" id="ihI-wv-eAy"/>
                         <constraint firstItem="Rip-IW-WHk" firstAttribute="leading" secondItem="h1E-cB-8ea" secondAttribute="leading" id="joM-X2-8BF"/>
+                        <constraint firstItem="zjp-Rf-XIT" firstAttribute="top" secondItem="2ns-ac-Nxb" secondAttribute="bottom" constant="10" id="qi3-OT-SkM"/>
+                        <constraint firstItem="zjp-Rf-XIT" firstAttribute="leading" secondItem="h1E-cB-8ea" secondAttribute="leading" id="rva-gG-56f"/>
                         <constraint firstAttribute="bottom" secondItem="Rip-IW-WHk" secondAttribute="bottom" id="sRz-IN-NOf"/>
                         <constraint firstItem="2ns-ac-Nxb" firstAttribute="leading" secondItem="h1E-cB-8ea" secondAttribute="leading" id="zDQ-nG-sPw"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1lC-3T-7VL" userLabel="레이블 View">
-                    <rect key="frame" x="15" y="245" width="349" height="80.5"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1lC-3T-7VL" userLabel="레이블 View">
+                    <rect key="frame" x="15" y="168" width="349" height="80.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="레이블" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RxK-mE-nmP">
                             <rect key="frame" x="0.0" y="0.0" width="52" height="24"/>
@@ -172,8 +163,8 @@
                         <constraint firstItem="rB8-Nh-vWO" firstAttribute="top" secondItem="1lC-3T-7VL" secondAttribute="top" id="ud3-qW-TbO"/>
                     </constraints>
                 </view>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JuN-a2-8rg" userLabel="마일스톤 View">
-                    <rect key="frame" x="15" y="345.5" width="349" height="80.5"/>
+                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JuN-a2-8rg" userLabel="마일스톤 View">
+                    <rect key="frame" x="15" y="268.5" width="349" height="80.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="마일스톤" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cZ2-6a-9EC">
                             <rect key="frame" x="0.0" y="0.0" width="69.5" height="24"/>
@@ -285,7 +276,6 @@
     <resources>
         <image name="arrow.down" catalog="system" width="120" height="128"/>
         <image name="arrow.up" catalog="system" width="120" height="128"/>
-        <image name="person.crop.square" catalog="system" width="128" height="114"/>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueList.storyboard
@@ -197,6 +197,96 @@
             </objects>
             <point key="canvasLocation" x="134.78260869565219" y="88.392857142857139"/>
         </scene>
+        <!--Assignee Select Controller-->
+        <scene sceneID="guN-ZA-fcj">
+            <objects>
+                <viewController storyboardIdentifier="AssigneeSelectController" id="0cN-FS-GAb" customClass="AssigneeSelectController" customModule="IssueTracker" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="RAq-Kk-Bht">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="NRy-CY-SNR">
+                                <rect key="frame" x="0.0" y="88" width="414" height="774"/>
+                                <color key="backgroundColor" systemColor="systemGray6Color"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="AssigneeCell" rowHeight="76" id="nvN-Ta-pkC" customClass="AssigneeCell" customModule="IssueTracker" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="55.5" width="414" height="76"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nvN-Ta-pkC" id="MnY-VL-TlW">
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="76"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VqJ-gN-MgR">
+                                                    <rect key="frame" x="20" y="28" width="42" height="21"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="bottomMargin" secondItem="VqJ-gN-MgR" secondAttribute="bottom" constant="16" id="DFl-ce-XF4"/>
+                                                <constraint firstItem="VqJ-gN-MgR" firstAttribute="leading" secondItem="MnY-VL-TlW" secondAttribute="leadingMargin" id="m8F-zV-2Rr"/>
+                                                <constraint firstItem="VqJ-gN-MgR" firstAttribute="top" secondItem="MnY-VL-TlW" secondAttribute="topMargin" constant="17" id="pyU-Gz-wXZ"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="userID" destination="VqJ-gN-MgR" id="Aa2-ar-fdj"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
+                                <connections>
+                                    <outlet property="dataSource" destination="0cN-FS-GAb" id="VCt-0e-pIC"/>
+                                    <outlet property="delegate" destination="0cN-FS-GAb" id="yiE-Z1-Eyw"/>
+                                </connections>
+                            </tableView>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="18n-w2-JD2"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="NRy-CY-SNR" firstAttribute="bottom" secondItem="18n-w2-JD2" secondAttribute="bottom" id="9G3-Zp-hGz"/>
+                            <constraint firstItem="NRy-CY-SNR" firstAttribute="top" secondItem="18n-w2-JD2" secondAttribute="top" id="DgP-b4-dZe"/>
+                            <constraint firstItem="NRy-CY-SNR" firstAttribute="leading" secondItem="18n-w2-JD2" secondAttribute="leading" id="MdQ-cJ-As3"/>
+                            <constraint firstItem="NRy-CY-SNR" firstAttribute="trailing" secondItem="18n-w2-JD2" secondAttribute="trailing" id="nya-dV-0TK"/>
+                        </constraints>
+                    </view>
+                    <navigationItem key="navigationItem" id="6q2-gC-R3f">
+                        <barButtonItem key="leftBarButtonItem" title="취소" id="WiO-as-Lru">
+                            <connections>
+                                <action selector="cancelButtonTapped:" destination="0cN-FS-GAb" id="ZWw-jC-dR3"/>
+                            </connections>
+                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="완료" id="ZwV-31-XaA">
+                            <connections>
+                                <action selector="doneButtonTapped:" destination="0cN-FS-GAb" id="bzP-T7-odJ"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="tableView" destination="NRy-CY-SNR" id="Ngd-fU-YUA"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="g1k-Iy-n27" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1928.985507246377" y="701.78571428571422"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="dDf-nz-XO3">
+            <objects>
+                <navigationController storyboardIdentifier="AssigneeNavigationController" automaticallyAdjustsScrollViewInsets="NO" id="7KW-pb-w3N" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="hE8-Vc-KlN">
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="0cN-FS-GAb" kind="relationship" relationship="rootViewController" id="IIW-gg-02n"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="qqW-Xf-JO6" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1177" y="703"/>
+        </scene>
     </scenes>
     <resources>
         <image name="exclamationmark.circle" catalog="system" width="128" height="121"/>
@@ -207,6 +297,9 @@
         </systemColor>
         <systemColor name="systemGray2Color">
             <color red="0.68235294117647061" green="0.68235294117647061" blue="0.69803921568627447" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemGray6Color">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="tertiarySystemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/DetailIssueList/DetailIssueListController.swift
@@ -66,6 +66,8 @@ final class DetailIssueListController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        cardView.issueInfo = issueInfo
+        
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: "편집", style: .plain, target: self, action: #selector(edit))
         
@@ -96,7 +98,7 @@ final class DetailIssueListController: UIViewController {
 
 // MARK: 카드뷰(풀업뷰)
 extension DetailIssueListController {
-        
+
     private func setUpDimmerView() {
         dimmerView.isUserInteractionEnabled = false
         dimmerView.alpha = 0

--- a/iOS/IssueTracker/IssueTracker/Controller/Filter/Filter.storyboard
+++ b/iOS/IssueTracker/IssueTracker/Controller/Filter/Filter.storyboard
@@ -343,14 +343,14 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="MileStoneConditionCell" id="YAa-8k-RXg" customClass="MileStoneConditionCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="57.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="57"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="YAa-8k-RXg" id="hLa-Pg-tR3">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="57.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="57"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oNp-a4-3UR">
-                                                    <rect key="frame" x="27" y="18" width="42" height="21.5"/>
+                                                    <rect key="frame" x="27" y="18" width="42" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -404,14 +404,14 @@
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="UserConditionCell" id="qA6-gg-Q5O" customClass="UserConditionCell" customModule="IssueTracker" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="57"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="57.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qA6-gg-Q5O" id="09L-JT-l9k">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="57"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="57.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UbX-Vy-tbi">
-                                                    <rect key="frame" x="27" y="18" width="42" height="21"/>
+                                                    <rect key="frame" x="27" y="18" width="42" height="21.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -424,7 +424,7 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                         <connections>
-                                            <outlet property="label" destination="UbX-Vy-tbi" id="zNl-yi-J1R"/>
+                                            <outlet property="label" destination="UbX-Vy-tbi" id="RcM-Yb-sXQ"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>

--- a/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
+++ b/iOS/IssueTracker/IssueTracker/Controller/ManageMilestone/ManageMilestoneViewController.swift
@@ -17,7 +17,6 @@ final class ManageMilestoneViewController: UIViewController, UICollectionViewDel
         super.viewDidLoad()
         setUpMilestoneData()
         
-      Layout()
         collectionView.dataSource = self
         collectionView.delegate = self
     }
@@ -138,8 +137,8 @@ final class MilestoneCell: UICollectionViewCell {
     @IBOutlet var closedIssueCount: UILabel!
         
     fileprivate func configure(milestoneData: MilestoneInfo) {
-        let numberOfOpenIssues = milestoneData.issues.filter { $0.status == "open" }.count
-        let numberOfClosedIssues = milestoneData.issues.filter { $0.status == "closed" }.count
+        guard let numberOfOpenIssues = milestoneData.issues?.filter({ $0.status == "open" }).count,
+              let numberOfClosedIssues = milestoneData.issues?.filter({ $0.status == "closed" }).count else { return }
         let numberFormatter = NumberFormatter()
         numberFormatter.numberStyle = .percent
         numberFormatter.locale = Locale(identifier: "en_US")

--- a/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/APIManager/BackEndAPIManager.swift
@@ -105,4 +105,19 @@ class BackEndAPIManager {
 
         }
     }
+    
+    func requestAddAssignee(issueNumber: String, userID: Int, completionHandler: @escaping ((Result<Assignee, APIError>) -> Void)) {
+        
+        router.request(route: BackEndAPI.addAssignee(issueNumber: issueNumber, userID: userID)) { (result: Result<Assignee, APIError>) in
+            completionHandler(result)
+        }
+    }
+    
+    func requestDeleteAssignee(issueNumber: String, userID: Int, completionHandler: @escaping ((Result<Assignee, APIError>) -> Void)) {
+        
+        router.request(route: BackEndAPI.deleteAssignee(issueNumber: issueNumber, userID: userID)) { (result: Result<Assignee, APIError>) in
+            completionHandler(result)
+        }
+    }
+    
 }

--- a/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/BackEndAPI.swift
@@ -27,6 +27,9 @@ enum BackEndAPI {
     case predefinedFilter(query: String)
     case closeIssue(issueNumber: String, title: String, status: String)
     
+    case addAssignee(issueNumber: String, userID: Int),
+         deleteAssignee(issueNumber: String, userID: Int)
+    
     case photo(path: String)
 }
 
@@ -57,7 +60,12 @@ extension BackEndAPI: EndPointable {
             return "http://\(BackEndAPICredentials.ip)/api/milestone/\(milestoneId)"
         case .photo(let path):
             return "\(path)"
+        case .addAssignee(let issueNumber, _):
+            return "http://\(BackEndAPICredentials.ip)/api/issue/\(issueNumber)/assignee"
+        case .deleteAssignee(let issueNumber, let userID):
+            return "http://\(BackEndAPICredentials.ip)/api/issue/\(issueNumber)/assignee/\(userID)"
         }
+        
     }
     
     var baseURL: URLComponents {
@@ -92,6 +100,10 @@ extension BackEndAPI: EndPointable {
             return .put
         case .photo:
             return .get
+        case .addAssignee:
+            return .post
+        case .deleteAssignee:
+            return .delete
         default:
             return nil
         }
@@ -119,6 +131,8 @@ extension BackEndAPI: EndPointable {
                                   "due_date": milestoneDueDate,
                                   "description": milestoneDescription]
             return bodyDictionary
+        case .addAssignee(_, let userID):
+            return ["user_id": "\(userID)"]
         default:
             return nil
         }

--- a/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/EndPointable.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/Network/EndPoint/EndPointable.swift
@@ -19,7 +19,8 @@ protocol EndPointable {
 enum HTTPMethod: String {
     case post,
          get,
-         put
+         put,
+         delete
 }
 public typealias HTTPHeader = [String: String]
 public typealias HTTPBody = [String: String]

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Assignees.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Assignees.swift
@@ -30,6 +30,8 @@ struct Assignee: Codable { // User 로 바꾸기
     let createdAt, updatedAt: String?
     let deletedAt: String?
 
+    var data: Data?
+    
     enum CodingKeys: String, CodingKey {
         case id
         case userID = "user_id"
@@ -40,6 +42,10 @@ struct Assignee: Codable { // User 로 바꾸기
 
 extension Assignee: Hashable {
     static func == (lhs: Assignee, rhs: Assignee) -> Bool {
-        return lhs.id == rhs.id
+        return lhs.userID == rhs.userID
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(userID)
     }
 }

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/Comment.swift
@@ -10,16 +10,14 @@ import Foundation
 struct Comment: Codable {
     let id: Int
     let content, createdAt, updatedAt: String
-    let deletedAt: String?
     let userID: Int?
     let issueID: Int
     let mentions: Assignee?
 
     enum CodingKeys: String, CodingKey {
         case id, content
-        case createdAt
-        case updatedAt
-        case deletedAt
+        case createdAt = "created_at"
+        case updatedAt = "updated_at"
         case userID = "user_id"
         case issueID = "issue_id"
         case mentions

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/FilterConditions/MilestoneInfo.swift
@@ -14,8 +14,9 @@ struct MilestonesInfo: Codable {
 // MARK: - Milestone
 struct MilestoneInfo: Codable {
     let id: Int
-    let title, dueDate, description: String
-    let issues: [IssuesInMilestone]
+    let title, dueDate: String
+    let description: String?
+    let issues: [IssuesInMilestone]?
   
     enum CodingKeys: String, CodingKey {
         case id, title, description, issues

--- a/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
+++ b/iOS/IssueTracker/IssueTracker/Model/ValueObject/IssueInfo.swift
@@ -18,7 +18,7 @@ struct IssueInfo: Codable {
     let userID: Int
     let milestoneID: Int?
     let labels: [LabelInfo]?
-    let assignees: [Assignee]?
+    var assignees: [Assignee]?
     let author: Author?
     let comments: [Comment]?
     let milestone: MilestoneInfo?

--- a/iOS/IssueTracker/IssueTracker/View/AssigneesProfileStackView.swift
+++ b/iOS/IssueTracker/IssueTracker/View/AssigneesProfileStackView.swift
@@ -1,0 +1,94 @@
+//
+//  AssigneesProfileStackView.swift
+//  IssueTracker
+//
+//  Created by a1111 on 2020/11/12.
+//
+
+import UIKit
+
+final class AssigneesProfileStackView: UIStackView {
+    
+    // MARK: - Property
+    
+    let maxProfileImageInLine = 4
+    
+    // MARK: - Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+    }
+    
+    required init(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    
+    // MARK: - Method
+    
+    func initializeView() {
+        subviews.forEach {
+            $0.removeFromSuperview()
+        }
+    }
+    
+    func fillEmptySpace(of assignees: [Assignee?]) -> [Assignee?] {
+        var assignees = assignees
+        (0..<(maxProfileImageInLine - (assignees.count % 4))).forEach { _ in
+            assignees.append(nil)
+        }
+        return assignees
+    }
+    
+    func stackView(axis: NSLayoutConstraint.Axis, distribution: UIStackView.Distribution = .fill) -> UIStackView {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = axis
+        stackView.distribution = distribution
+        stackView.spacing = 10
+        
+        return stackView
+    }
+    
+    func configure(by assignees: [Assignee?]) {
+        
+        let filledAssignees = fillEmptySpace(of: assignees)
+        
+        var multipleStackView = stackView(axis: .horizontal, distribution: .fillEqually)
+        
+        filledAssignees.enumerated().forEach { (index, assignee) in
+            
+            if index % maxProfileImageInLine == 0 && index != 0 {
+                addArrangedSubview(multipleStackView)
+                multipleStackView = stackView(axis: .horizontal, distribution: .fillEqually)
+            }
+            
+            let profileInfoStackView = stackView(axis: .vertical)
+            
+            // 1. 담당자 이미지 추가
+            let profileImageView = UIImageView()
+            profileImageView.layer.cornerRadius = 10
+            profileImageView.layer.masksToBounds = true
+            if let data = assignee?.data { profileImageView.image = UIImage(data: data) }
+            
+            profileInfoStackView.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                profileImageView.widthAnchor.constraint(equalToConstant: 70),
+                profileImageView.widthAnchor.constraint(equalTo: profileImageView.heightAnchor)
+            ])
+            
+            profileImageView.backgroundColor = UIColor.clear
+            profileInfoStackView.addArrangedSubview(profileImageView)
+            
+            // 2. 담당자 아이디 추가
+            let idLabel = UILabel()
+            idLabel.font = .systemFont(ofSize: 10)
+            idLabel.textAlignment = .center
+            idLabel.text = assignee?.userID
+            profileInfoStackView.addArrangedSubview(idLabel)
+            
+            multipleStackView.addArrangedSubview(profileInfoStackView)
+        }
+        addArrangedSubview(multipleStackView)
+    }
+}


### PR DESCRIPTION
# 이슈의 담당자를 조회/변경할 수 있다.

## 해당 이슈 📎

#248 

## 변경 사항 🛠

- 카드뷰(풀업뷰)에 이슈의 담당자에 대한 프로필 사진, 아이디가 나와야 한다.
- 수정 버튼을 클릭하면 새로운 화면으로 가고 해당 화면에서 담당자를 추가/제거할 수 있어야 한다.
- 완료 버튼을 누를 시 선택한 담당자들의 정보가 화면으로 갱신되야 한다.
- 갱신된 내용은 서버에도 반영되야 한다.

## 테스트 ✨

없음

## 리뷰어 참고 사항 🙋‍♀️

